### PR TITLE
[DNM] Improve free_to

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -21,6 +21,6 @@ fn main() {
     suites::bench_raw_node(&mut c);
     suites::bench_progress(&mut c);
     suites::bench_progress_set(&mut c);
-
+    suites::bench_inflights(&mut c);
     c.final_summary();
 }

--- a/benches/suites/inflights.rs
+++ b/benches/suites/inflights.rs
@@ -8,20 +8,20 @@ pub fn bench_inflights(c: &mut Criterion) {
 
 pub fn bench_inflights_add(c: &mut Criterion) {
     c.bench_function("Inflights::add", |b: &mut Bencher| {
-        b.iter_batched(
+        b.iter_batched_ref(
             || Inflights::new(256),
-            |mut i| i.add(1),
-            BatchSize::SmallInput,
+            |i| i.add(1),
+            BatchSize::PerIteration,
         );
     });
 }
 
 pub fn bench_inflights_free_to(c: &mut Criterion) {
-    let sizes: Vec<u64> = vec![64, 256, 1024, 4096, 16384];
+    let sizes: Vec<u64> = vec![64, 256, 1024, 4096, 16384, 64 * 1024];
     let mut group = c.benchmark_group("Inflights::free_to");
     for s in sizes {
         let test_idx = vec![
-            0,
+            1,
             (s as f64).log(2f64) as u64,
             s / 4,
             s / 2,
@@ -37,10 +37,10 @@ pub fn bench_inflights_free_to(c: &mut Criterion) {
                     for i in 0..*size {
                         inflights.add(i);
                     }
-                    b.iter_batched(
+                    b.iter_batched_ref(
                         || inflights.clone(),
-                        |mut i| i.free_to(*free_to),
-                        BatchSize::SmallInput,
+                        |i| i.free_to(*free_to),
+                        BatchSize::PerIteration,
                     );
                 },
             );

--- a/benches/suites/inflights.rs
+++ b/benches/suites/inflights.rs
@@ -2,7 +2,7 @@ use criterion::{BatchSize, Bencher, BenchmarkId, Criterion};
 use raft::Inflights;
 
 pub fn bench_inflights(c: &mut Criterion) {
-    bench_inflights_add(c);
+    // bench_inflights_add(c);
     bench_inflights_free_to(c);
 }
 
@@ -23,7 +23,7 @@ pub fn bench_inflights_free_to(c: &mut Criterion) {
         let test_idx = vec![0, (s as f64).log(2f64) as u64, s/4, s/2, s/2 + s/4, s - 1];
         for i in test_idx {
             group.bench_with_input(
-                BenchmarkId::new("", format!("{}@{}", s, i)),
+                BenchmarkId::from_parameter(format!("{}@{}", s, i)),
                 &(s, i),
                 |b: &mut Bencher, (size, free_to)| {
                     let mut inflights = Inflights::new(*size as usize);

--- a/benches/suites/inflights.rs
+++ b/benches/suites/inflights.rs
@@ -2,7 +2,7 @@ use criterion::{BatchSize, Bencher, BenchmarkId, Criterion};
 use raft::Inflights;
 
 pub fn bench_inflights(c: &mut Criterion) {
-    // bench_inflights_add(c);
+    bench_inflights_add(c);
     bench_inflights_free_to(c);
 }
 

--- a/benches/suites/inflights.rs
+++ b/benches/suites/inflights.rs
@@ -1,0 +1,38 @@
+use criterion::{BatchSize, Bencher, BenchmarkId, Criterion};
+use raft::Inflights;
+
+pub fn bench_inflights(c: &mut Criterion) {
+    bench_inflights_add(c);
+    bench_inflights_free_to(c);
+}
+
+pub fn bench_inflights_add(c: &mut Criterion) {
+    c.bench_function("Inflights::add", |b: &mut Bencher| {
+        b.iter_batched(
+            || Inflights::new(256),
+            |mut i| i.add(1),
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+pub fn bench_inflights_free_to(c: &mut Criterion) {
+    let sizes: Vec<u64> = vec![64, 256, 1024, 4096, 16384];
+    let mut group = c.benchmark_group("Inflights::free_to");
+    for s in sizes {
+        let test_idx = vec![0, (s as f64).log(2f64) as u64, s/4, s/2, s/2 + s/4, s - 1];
+        for i in test_idx {
+            group.bench_with_input(
+                BenchmarkId::new("", format!("{}@{}", s, i)),
+                &(s, i),
+                |b: &mut Bencher, (size, free_to)| {
+                    let mut inflights = Inflights::new(*size as usize);
+                    for i in 0..*size {
+                        inflights.add(i);
+                    }
+                    b.iter_batched(|| inflights.clone(), |mut i| i.free_to(*free_to), BatchSize::SmallInput);
+                },
+            );
+        }
+    }
+}

--- a/benches/suites/inflights.rs
+++ b/benches/suites/inflights.rs
@@ -20,7 +20,14 @@ pub fn bench_inflights_free_to(c: &mut Criterion) {
     let sizes: Vec<u64> = vec![64, 256, 1024, 4096, 16384];
     let mut group = c.benchmark_group("Inflights::free_to");
     for s in sizes {
-        let test_idx = vec![0, (s as f64).log(2f64) as u64, s/4, s/2, s/2 + s/4, s - 1];
+        let test_idx = vec![
+            0,
+            (s as f64).log(2f64) as u64,
+            s / 4,
+            s / 2,
+            s / 2 + s / 4,
+            s - 1,
+        ];
         for i in test_idx {
             group.bench_with_input(
                 BenchmarkId::from_parameter(format!("{}@{}", s, i)),
@@ -30,7 +37,11 @@ pub fn bench_inflights_free_to(c: &mut Criterion) {
                     for i in 0..*size {
                         inflights.add(i);
                     }
-                    b.iter_batched(|| inflights.clone(), |mut i| i.free_to(*free_to), BatchSize::SmallInput);
+                    b.iter_batched(
+                        || inflights.clone(),
+                        |mut i| i.free_to(*free_to),
+                        BatchSize::SmallInput,
+                    );
                 },
             );
         }

--- a/benches/suites/inflights.rs
+++ b/benches/suites/inflights.rs
@@ -1,3 +1,5 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
 use criterion::{BatchSize, Bencher, BenchmarkId, Criterion};
 use raft::Inflights;
 

--- a/benches/suites/mod.rs
+++ b/benches/suites/mod.rs
@@ -8,3 +8,5 @@ mod progress;
 pub use self::progress::*;
 mod progress_set;
 pub use self::progress_set::*;
+mod inflights;
+pub use self::inflights::*;

--- a/src/progress/inflights.rs
+++ b/src/progress/inflights.rs
@@ -88,13 +88,13 @@ impl Inflights {
         }
         let mut start = self.start;
         let mut end = self.start + self.count - 1;
-        let mut mid = (start + end ) / 2;
+        let mut mid = (start + end) / 2;
         // To find first value >= to
         while start < end {
             let mid_v = self.buffer[self.rotate(mid)];
             if mid_v < to {
                 start = mid + 1;
-            } else if mid_v > to{
+            } else if mid_v > to {
                 end = mid;
             } else {
                 break;

--- a/src/progress/inflights.rs
+++ b/src/progress/inflights.rs
@@ -86,27 +86,34 @@ impl Inflights {
             // out of the left side of the window
             return;
         }
-
-        let mut i = 0usize;
-        let mut idx = self.start;
-        while i < self.count {
-            if to < self.buffer[idx] {
-                // found the first large inflight
+        let mut start = self.start;
+        let mut end = self.start + self.count - 1;
+        let mut mid = (start + end ) / 2;
+        // To find first value >= to
+        while start < end {
+            let mid_v = self.buffer[self.rotate(mid)];
+            if mid_v < to {
+                start = mid + 1;
+            } else if mid_v > to{
+                end = mid;
+            } else {
                 break;
             }
-
-            // increase index and maybe rotate
-            idx += 1;
-            if idx >= self.cap() {
-                idx -= self.cap();
-            }
-
-            i += 1;
+            mid = (start + end) / 2;
         }
+        self.count -= mid + 1 - self.start;
+        self.start = self.rotate(mid) + 1;
+    }
 
-        // free i inflights and set new start index
-        self.count -= i;
-        self.start = idx;
+    // Rotate index if it's beyond the cap
+    #[inline]
+    fn rotate(&self, idx: usize) -> usize {
+        let cap = self.cap();
+        if idx >= cap {
+            idx - cap
+        } else {
+            idx
+        }
     }
 
     /// Frees the first buffer entry.

--- a/src/util.rs
+++ b/src/util.rs
@@ -109,3 +109,44 @@ pub(crate) fn format_kv_list(kv_list: &OwnedKVList) -> String {
         .unwrap();
     formatter.buffer
 }
+
+const TAB32: [usize; 32] = [
+    0, 9, 1, 10, 13, 21, 2, 29, 11, 14, 16, 18, 22, 25, 3, 30, 8, 12, 20, 28, 15, 17, 24, 7, 19,
+    27, 23, 6, 26, 5, 4, 31,
+];
+const TAB64: [usize; 64] = [
+    63, 0, 58, 1, 59, 47, 53, 2, 60, 39, 48, 27, 54, 33, 42, 3, 61, 51, 37, 40, 49, 18, 28, 20, 55,
+    30, 34, 11, 43, 14, 22, 4, 62, 57, 46, 52, 38, 26, 32, 41, 50, 36, 17, 19, 29, 10, 13, 21, 56,
+    45, 25, 31, 35, 16, 9, 12, 44, 24, 15, 8, 23, 7, 6, 5,
+];
+
+fn log2_32(mut n: usize) -> usize {
+    n |= n >> 1;
+    n |= n >> 2;
+    n |= n >> 4;
+    n |= n >> 8;
+    n |= n >> 16;
+    TAB32[n.overflowing_mul(0x07C4_ACDD).0 >> 27]
+}
+
+fn log2_64(mut n: usize) -> usize {
+    n |= n >> 1;
+    n |= n >> 2;
+    n |= n >> 4;
+    n |= n >> 8;
+    n |= n >> 16;
+    n |= n >> 32;
+    TAB64[(n - (n >> 1)).overflowing_mul(0x07ED_D5E5_9A4E_28C2).0 >> 58]
+}
+
+/// The quick log2
+#[cfg(target_pointer_width = "64")]
+pub fn log2(n: usize) -> usize {
+    log2_64(n)
+}
+
+/// The quick log2
+#[cfg(target_pointer_width = "32")]
+pub fn log2(mut n: usize) -> usize {
+    log2_32(n)
+}


### PR DESCRIPTION
Use Binary Search instead of Linear Search in `free_to` and add relate benchmarks.

## Bench Result
```
Inflights::free_to/64@0 time:   [129.33 ns 134.89 ns 140.37 ns]
                        change: [+0.3479% +8.6803% +18.047%] (p = 0.05 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
Inflights::free_to/64@6 time:   [126.03 ns 133.64 ns 142.15 ns]
                        change: [-6.5282% +2.4475% +12.238%] (p = 0.61 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
Inflights::free_to/64@16
                        time:   [127.97 ns 134.99 ns 142.34 ns]
                        change: [-11.196% -2.9282% +5.5251%] (p = 0.51 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Inflights::free_to/64@32
                        time:   [130.04 ns 137.27 ns 144.72 ns]
                        change: [-21.535% -14.753% -7.7207%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Inflights::free_to/64@48
                        time:   [128.06 ns 134.14 ns 140.62 ns]
                        change: [-36.361% -30.476% -24.428%] (p = 0.00 < 0.05)
                        Performance has improved.
Inflights::free_to/64@63
                        time:   [125.93 ns 131.81 ns 137.93 ns]
                        change: [-34.380% -28.776% -22.785%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
Inflights::free_to/256@0
                        time:   [92.512 ns 96.127 ns 99.768 ns]
                        change: [+8.1334% +22.507% +40.008%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) high mild
  6 (6.00%) high severe
Inflights::free_to/256@8
                        time:   [97.911 ns 101.71 ns 105.21 ns]
                        change: [+7.3463% +23.457% +45.876%] (p = 0.02 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
Inflights::free_to/256@64
                        time:   [110.95 ns 117.83 ns 124.59 ns]
                        change: [-36.738% -32.980% -28.922%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
Inflights::free_to/256@128
                        time:   [109.01 ns 114.19 ns 119.61 ns]
                        change: [-60.409% -58.175% -55.703%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
Inflights::free_to/256@192
                        time:   [103.50 ns 107.11 ns 110.52 ns]
                        change: [-68.973% -67.188% -64.837%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
Inflights::free_to/256@255
                        time:   [122.89 ns 127.26 ns 131.78 ns]
                        change: [-71.021% -69.327% -67.263%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
Inflights::free_to/1024@0
                        time:   [111.85 ns 115.40 ns 118.80 ns]
                        change: [+28.825% +49.292% +73.372%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
Inflights::free_to/1024@10
                        time:   [117.14 ns 122.60 ns 128.14 ns]
                        change: [+25.974% +39.473% +56.245%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
Inflights::free_to/1024@256
                        time:   [115.73 ns 122.16 ns 129.36 ns]
                        change: [-74.795% -73.191% -71.418%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
Inflights::free_to/1024@512
                        time:   [124.00 ns 128.97 ns 134.10 ns]
                        change: [-82.226% -80.766% -78.773%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe
Inflights::free_to/1024@768
                        time:   [124.97 ns 130.39 ns 136.01 ns]
                        change: [-87.938% -86.974% -85.828%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe
Inflights::free_to/1024@1023
                        time:   [131.33 ns 157.64 ns 206.95 ns]
                        change: [-90.876% -89.816% -88.273%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
Inflights::free_to/4096@0
                        time:   [1.0208 us 1.2441 us 1.4336 us]
                        change: [-16.970% +25.455% +91.599%] (p = 0.28 > 0.05)
                        No change in performance detected.
Inflights::free_to/4096@12
                        time:   [1.0144 us 1.2620 us 1.4707 us]
                        change: [-17.191% +24.278% +87.836%] (p = 0.29 > 0.05)
                        No change in performance detected.
Inflights::free_to/4096@1024
                        time:   [1.0016 us 1.2439 us 1.4521 us]
                        change: [-68.291% -57.908% -44.113%] (p = 0.00 < 0.05)
                        Performance has improved.
Inflights::free_to/4096@2048
                        time:   [993.37 ns 1.2161 us 1.4039 us]
                        change: [-81.659% -75.628% -67.818%] (p = 0.00 < 0.05)
                        Performance has improved.
Inflights::free_to/4096@3072
                        time:   [1.0437 us 1.2743 us 1.4673 us]
                        change: [-86.708% -82.857% -78.546%] (p = 0.00 < 0.05)
                        Performance has improved.
Inflights::free_to/4096@4095
                        time:   [1.0184 us 1.2433 us 1.4322 us]
                        change: [-91.132% -87.923% -84.634%] (p = 0.00 < 0.05)
                        Performance has improved.
Inflights::free_to/16384@0
                        time:   [4.3876 us 4.7562 us 5.0588 us]
                        change: [-16.140% +3.0053% +27.902%] (p = 0.78 > 0.05)
                        No change in performance detected.
Inflights::free_to/16384@14
                        time:   [4.0367 us 4.4050 us 4.7188 us]
                        change: [-27.012% -10.294% +11.348%] (p = 0.33 > 0.05)
                        No change in performance detected.
Inflights::free_to/16384@4096
                        time:   [4.2099 us 4.5814 us 4.8818 us]
                        change: [-68.759% -62.836% -57.190%] (p = 0.00 < 0.05)
                        Performance has improved.
Inflights::free_to/16384@8192
                        time:   [4.3191 us 4.6934 us 5.0021 us]
                        change: [-79.622% -75.919% -72.027%] (p = 0.00 < 0.05)
                        Performance has improved.
Inflights::free_to/16384@12288
                        time:   [4.3328 us 4.7174 us 5.0344 us]
                        change: [-85.755% -83.421% -80.859%] (p = 0.00 < 0.05)
                        Performance has improved.
Inflights::free_to/16384@16383
                        time:   [4.4048 us 4.8108 us 5.1492 us]
                        change: [-88.752% -86.733% -84.698%] (p = 0.00 < 0.05)
                        Performance has improved.
```

## Some thinkings

Because of the Binary Search algorithm, `free_to` the first `log(n)` items in `Inflights` can be slower than the origin Linear Search implementation.

And in the scenario of streaming messages, where the ProgressState of the follower is `Replicate`, the leader always frees the previous few items in `Inflights` each time receiving a `MsgAppendResp` so that Binary Search here may not be as the same obvious improvement as in bench results above.

But we can adjust the implementation to dynamically using Binary or Linear Search according to the receiving `idx`. Furthermore, maybe we can merge multiple continuously produced `MsgAppendResp` into one message benefitting from the fewer leader steps and network costs.

@Hoverbear @BusyJay @hicqu @siddontang 

