### PR TITLE
downgrade dependency prost from 0.6 to 0.5

### DIFF
--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -15,12 +15,13 @@ build = "build.rs"
 [features]
 default = ["protobuf-codec"]
 protobuf-codec = ["protobuf-build/protobuf-codec"]
-prost-codec = ["protobuf-build/prost-codec", "prost", "lazy_static"]
+prost-codec = ["protobuf-build/prost-codec", "prost", "bytes", "lazy_static"]
 
 [build-dependencies]
 protobuf-build = { version = "0.10", default-features = false }
 
 [dependencies]
 lazy_static = { version = "1", optional = true }
-prost = { version = "0.6", optional = true }
+bytes = { version = "0.4", optional = true }
+prost = { version = "0.5", optional = true }
 protobuf = "2"


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

Otherwise the latest raft can't be cmpiled with kvproto and tikv. Please take a look at https://github.com/tikv/tikv/pull/6578.
This PR changes prost to the same version with kvproto.