### PR TITLE
advance commit index by MsgReadIndexResp

### DIFF
--- a/harness/src/network.rs
+++ b/harness/src/network.rs
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use raft::{
     eraftpb::{ConfState, Message, MessageType},
@@ -50,6 +50,8 @@ pub struct Network {
     dropm: HashMap<Connection, f64>,
     /// Drop messages of type `MessageType`.
     ignorem: HashMap<MessageType, bool>,
+    /// Drop messages of type `MessageType` to `to`.
+    ignorem_to: HashMap<u64, HashSet<MessageType>>,
 }
 
 impl Network {
@@ -120,6 +122,14 @@ impl Network {
         self.ignorem.insert(t, true);
     }
 
+    /// Ignore messages with a given `MessageType` and to `to`.
+    pub fn ignore_to(&mut self, to: u64, t: MessageType) {
+        self.ignorem_to
+            .entry(to)
+            .or_insert(HashSet::new())
+            .insert(t);
+    }
+
     /// Filter out messages that should be dropped according to rules set by `ignore` or `drop`.
     pub fn filter(&self, msgs: impl IntoIterator<Item = Message>) -> Vec<Message> {
         msgs.into_iter()
@@ -132,6 +142,13 @@ impl Network {
                 {
                     return false;
                 }
+
+                if let Some(set) = self.ignorem_to.get(&m.to) {
+                    if set.contains(&m.get_msg_type()) {
+                        return false;
+                    }
+                }
+
                 // hups never go over the network, so don't drop them but panic
                 assert_ne!(m.get_msg_type(), MessageType::MsgHup, "unexpected msgHup");
                 let perc = self
@@ -221,5 +238,6 @@ impl Network {
     pub fn recover(&mut self) {
         self.dropm = HashMap::new();
         self.ignorem = HashMap::new();
+        self.ignorem_to = HashMap::new();
     }
 }

--- a/harness/src/network.rs
+++ b/harness/src/network.rs
@@ -126,7 +126,7 @@ impl Network {
     pub fn ignore_to(&mut self, to: u64, t: MessageType) {
         self.ignorem_to
             .entry(to)
-            .or_insert(HashSet::new())
+            .or_insert_with(HashSet::new)
             .insert(t);
     }
 

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -2453,20 +2453,18 @@ fn test_advance_commit_index_by_read_index_response() {
     tt.cut(1, 3);
     tt.cut(1, 4);
     tt.cut(1, 5);
-
     tt.send(vec![new_message(1, 1, MessageType::MsgPropose, 1)]);
     tt.send(vec![new_message(1, 1, MessageType::MsgPropose, 1)]);
 
-    // network recovery
     tt.recover();
-    // node 2' commit index will not be advanced by these msgs
-    tt.ignore_to(2, MessageType::MsgAppend);
-    tt.ignore_to(2, MessageType::MsgHeartbeat);
+    tt.cut(1, 2);
 
-    tt.peers.get_mut(&1).unwrap().raft_log.commit_to(4);
+    // commit entries for leader but not node 2
+    tt.send(vec![new_message(3, 1, MessageType::MsgReadIndex, 1)]);
     assert_eq!(tt.peers[&1].raft_log.committed, 4);
     assert_eq!(tt.peers[&2].raft_log.committed, 2);
 
+    tt.recover();
     tt.send(vec![new_message(2, 1, MessageType::MsgReadIndex, 1)]);
     assert_eq!(tt.peers[&2].raft_log.committed, 4);
 }

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -2465,6 +2465,8 @@ fn test_advance_commit_index_by_read_index_response() {
     assert_eq!(tt.peers[&2].raft_log.committed, 2);
 
     tt.recover();
+    // use LeaseBased so leader won't send MsgHeartbeat to advance node 2's commit index
+    tt.peers.get_mut(&1).unwrap().read_only.option = ReadOnlyOption::LeaseBased;
     tt.send(vec![new_message(2, 1, MessageType::MsgReadIndex, 1)]);
     assert_eq!(tt.peers[&2].raft_log.committed, 4);
 }

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -2441,6 +2441,36 @@ fn test_read_only_for_new_leader() {
     assert_eq!(rs.request_ctx, wctx.as_bytes().to_vec());
 }
 
+// `test_advance_commit_index_by_read_index_response` ensures that read index response
+// can advance the follower's commit index if it has new enough logs
+#[test]
+fn test_advance_commit_index_by_read_index_response() {
+    let l = default_logger();
+    let mut tt = Network::new(vec![None, None, None, None, None], &l);
+    tt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
+
+    // don't commit entries
+    tt.cut(1, 3);
+    tt.cut(1, 4);
+    tt.cut(1, 5);
+
+    tt.send(vec![new_message(1, 1, MessageType::MsgPropose, 1)]);
+    tt.send(vec![new_message(1, 1, MessageType::MsgPropose, 1)]);
+
+    // network recovery
+    tt.recover();
+    // node 2' commit index will not be advanced by these msgs
+    tt.ignore_to(2, MessageType::MsgAppend);
+    tt.ignore_to(2, MessageType::MsgHeartbeat);
+
+    tt.peers.get_mut(&1).unwrap().raft_log.commit_to(4);
+    assert_eq!(tt.peers[&1].raft_log.committed, 4);
+    assert_eq!(tt.peers[&2].raft_log.committed, 2);
+
+    tt.send(vec![new_message(2, 1, MessageType::MsgReadIndex, 1)]);
+    assert_eq!(tt.peers[&2].raft_log.committed, 4);
+}
+
 #[test]
 fn test_leader_append_response() {
     let l = default_logger();

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1826,6 +1826,7 @@ impl<T: Storage> Raft<T> {
                     request_ctx: m.take_entries()[0].take_data(),
                 };
                 self.read_states.push(rs);
+                self.raft_log.maybe_commit(m.commit, m.term);
             }
             _ => {}
         }

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1826,6 +1826,9 @@ impl<T: Storage> Raft<T> {
                     request_ctx: m.take_entries()[0].take_data(),
                 };
                 self.read_states.push(rs);
+                // `index` and `term` in MsgReadIndexResp is the leader's commit index and its current term,
+                // the log entry in the leader's commit index will always have the leader's current term,
+                // because the leader only handle MsgReadIndex after it has committed log entry in its term.
                 self.raft_log.maybe_commit(m.index, m.term);
             }
             _ => {}

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1826,7 +1826,7 @@ impl<T: Storage> Raft<T> {
                     request_ctx: m.take_entries()[0].take_data(),
                 };
                 self.read_states.push(rs);
-                self.raft_log.maybe_commit(m.commit, m.term);
+                self.raft_log.maybe_commit(m.index, m.term);
             }
             _ => {}
         }


### PR DESCRIPTION
Signed-off-by: linning <linningde25@gmail.com>
Leader only handle `MsgReadIndex` when it has committed log entry in its term and the read index this leader returned always be its commit index , so log entries at the read index are always proposed and committed by this leader at its term, so if the follower's log entry match the read index and term on `MsgReadIndexResp` it can advance its commit index to the read index.
close #343 