### PR TITLE
Remove StatusRef

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -495,7 +495,7 @@ pub use self::raft::{vote_resp_msg_type, Raft, SoftState, StateRole, INVALID_ID,
 pub use self::raft_log::{RaftLog, NO_LIMIT};
 pub use self::raw_node::{is_empty_snap, Peer, RawNode, Ready, SnapshotStatus};
 pub use self::read_only::{ReadOnlyOption, ReadState};
-pub use self::status::{Status, StatusRef};
+pub use self::status::Status;
 pub use self::storage::{RaftState, Storage};
 pub use self::util::{majority, QuorumFn};
 pub use raft_proto::eraftpb;
@@ -524,7 +524,7 @@ pub mod prelude {
 
     pub use crate::progress::Progress;
 
-    pub use crate::status::{Status, StatusRef};
+    pub use crate::status::Status;
 
     pub use crate::read_only::{ReadOnlyOption, ReadState};
 }

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -31,7 +31,7 @@ use crate::eraftpb::{
 };
 use crate::errors::{Error, Result};
 use crate::read_only::ReadState;
-use crate::{QuorumFn, Raft, SoftState, Status, StatusRef, Storage, INVALID_ID};
+use crate::{QuorumFn, Raft, SoftState, Status, Storage, INVALID_ID};
 use slog::Logger;
 
 /// Represents a Peer node in the cluster.
@@ -433,13 +433,6 @@ impl<T: Storage> RawNode<T> {
     #[inline]
     pub fn status(&self) -> Status {
         Status::new(&self.raft)
-    }
-
-    /// Returns the current status of the given group.
-    ///
-    /// It's borrows the internal progress set instead of copying.
-    pub fn status_ref(&self) -> StatusRef {
-        StatusRef::new(&self.raft)
     }
 
     /// ReportUnreachable reports the given node is not reachable for the last send.

--- a/src/status.rs
+++ b/src/status.rs
@@ -51,35 +51,3 @@ impl<'a> Status<'a> {
         s
     }
 }
-
-/// Represents the current status of the raft
-#[derive(Default)]
-pub struct StatusRef<'a> {
-    /// The ID of the current node.
-    pub id: u64,
-    /// The hardstate of the raft, representing voted state.
-    pub hs: HardState,
-    /// The softstate of the raft, representing proposed state.
-    pub ss: SoftState,
-    /// The index of the last entry to have been applied.
-    pub applied: u64,
-    /// The progress towards catching up and applying logs.
-    pub progress: Option<&'a ProgressSet>,
-}
-
-impl<'a> StatusRef<'a> {
-    /// Gets the current raft status.
-    pub fn new<T: Storage>(raft: &'a Raft<T>) -> StatusRef<'a> {
-        let mut s = StatusRef {
-            id: raft.id,
-            ..Default::default()
-        };
-        s.hs = raft.hard_state();
-        s.ss = raft.soft_state();
-        s.applied = raft.raft_log.applied();
-        if s.ss.raft_state == StateRole::Leader {
-            s.progress = Some(raft.prs());
-        }
-        s
-    }
-}


### PR DESCRIPTION
This effectively revert part of 065c37d653daf654b8ef466e8f1658411264e3eb.

Because it is not necessary after b86e9e00067e5dcce10385c65506a38817d22430.

Normal Status also uses borrow now.