### PR TITLE
proto: look for sources relative to CARGO_MANIFEST_DIR

### DIFF
--- a/proto/build.rs
+++ b/proto/build.rs
@@ -3,5 +3,9 @@
 use protobuf_build::Builder;
 
 fn main() {
-    Builder::new().search_dir_for_protos("proto").generate()
+    let base = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+    Builder::new()
+        .search_dir_for_protos(&format!("{}/proto", base))
+        .includes(&[format!("{}/include", base), format!("{}/proto", base)])
+        .generate()
 }


### PR DESCRIPTION
This is a little more reliable than assuming the current dir is
the manifest dir.

Also override the default includes to also use the same path prefix, otherwise protoc complains.