### PR TITLE
[bug fix] Ready.must_sync

### DIFF
--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -338,27 +338,35 @@ fn test_raw_node_start() {
 
     let rd = raw_node.ready();
     must_cmp_ready(&rd, &None, &None, &[], vec![], false);
-
     store.wl().append(rd.entries()).unwrap();
     raw_node.advance(rd);
 
     raw_node.campaign().expect("");
     let rd = raw_node.ready();
+    must_cmp_ready(
+        &rd,
+        &Some(soft_state(1, StateRole::Leader)),
+        &Some(hard_state(2, 2, 1)),
+        &[new_entry(2, 2, None)],
+        vec![new_entry(2, 2, None)],
+        true,
+    );
     store.wl().append(rd.entries()).expect("");
     raw_node.advance(rd);
 
-    raw_node.propose(vec![], b"foo".to_vec()).expect("");
+    raw_node.propose(vec![], b"somedata".to_vec()).expect("");
     let rd = raw_node.ready();
     must_cmp_ready(
         &rd,
         &None,
         &Some(hard_state(2, 3, 1)),
-        &[new_entry(2, 3, Some("foo"))],
-        vec![new_entry(2, 3, Some("foo"))],
-        false,
+        &[new_entry(2, 3, SOME_DATA)],
+        vec![new_entry(2, 3, SOME_DATA)],
+        true,
     );
     store.wl().append(rd.entries()).expect("");
     raw_node.advance(rd);
+
     assert!(!raw_node.has_ready());
 }
 

--- a/harness/tests/test_util/mod.rs
+++ b/harness/tests/test_util/mod.rs
@@ -109,12 +109,19 @@ pub fn new_test_raft_with_config(config: &Config, storage: MemStorage, l: &Logge
     Interface::new(Raft::new(config, storage, l).unwrap())
 }
 
-pub fn hard_state(t: u64, c: u64, v: u64) -> HardState {
+pub fn hard_state(term: u64, commit: u64, vote: u64) -> HardState {
     let mut hs = HardState::default();
-    hs.term = t;
-    hs.commit = c;
-    hs.vote = v;
+    hs.term = term;
+    hs.commit = commit;
+    hs.vote = vote;
     hs
+}
+
+pub fn soft_state(leader_id: u64, raft_state: StateRole) -> SoftState {
+    SoftState {
+        leader_id,
+        raft_state,
+    }
 }
 
 pub const SOME_DATA: Option<&'static str> = Some("somedata");

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -137,7 +137,7 @@ impl Ready {
         }
         let hs = raft.hard_state();
         if &hs != prev_hs {
-            if hs.vote != prev_hs.vote || hs.term != prev_hs.term {
+            if hs.vote != prev_hs.vote || hs.term != prev_hs.term || !rd.entries.is_empty() {
                 rd.must_sync = true;
             }
             rd.hs = Some(hs);


### PR DESCRIPTION
close #128 

It seems that we can check `ready` in `test_raw_node_start`, thereforce I dont add another test function

And, refactor some parameter name for readability

Signed-off-by: accelsao <bebe8277@gmail.com>