### PR TITLE
remove storage error other

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -93,13 +93,6 @@ quick_error! {
         SnapshotTemporarilyUnavailable {
             description("snapshot is temporarily unavailable")
         }
-        /// Some other error occurred.
-        Other(err: Box<dyn std::error::Error + Sync + Send>) {
-            from()
-            cause(err.as_ref())
-            description(err.description())
-            display("unknown error {:?}", err)
-        }
     }
 }
 
@@ -174,9 +167,5 @@ mod tests {
             StorageError::SnapshotTemporarilyUnavailable
         );
         assert_ne!(StorageError::Compacted, StorageError::Unavailable);
-        assert_ne!(
-            StorageError::Other(Box::new(StorageError::Unavailable)),
-            StorageError::Unavailable
-        );
     }
 }


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

`StorageError::Other` is not used in raft-rs, it can be removed.