### PR TITLE
*: introduce joint quorum

### DIFF
--- a/benches/suites/progress_set.rs
+++ b/benches/suites/progress_set.rs
@@ -2,7 +2,7 @@
 
 use crate::DEFAULT_RAFT_SETS;
 use criterion::{Bencher, Criterion};
-use raft::{Progress, ProgressSet};
+use raft::{Progress, ProgressTracker};
 
 pub fn bench_progress_set(c: &mut Criterion) {
     bench_progress_set_new(c);
@@ -17,8 +17,8 @@ pub fn bench_progress_set(c: &mut Criterion) {
     bench_progress_set_learners(c);
 }
 
-fn quick_progress_set(voters: usize, learners: usize) -> ProgressSet {
-    let mut set = ProgressSet::with_capacity(voters, learners, raft::default_logger());
+fn quick_progress_set(voters: usize, learners: usize) -> ProgressTracker {
+    let mut set = ProgressTracker::with_capacity(voters, learners, 10, raft::default_logger());
     (0..voters).for_each(|id| {
         set.insert_voter(id as u64, Progress::new(0, 10)).ok();
     });
@@ -31,23 +31,23 @@ fn quick_progress_set(voters: usize, learners: usize) -> ProgressSet {
 pub fn bench_progress_set_new(c: &mut Criterion) {
     let bench = |b: &mut Bencher| {
         // No setup.
-        b.iter(|| ProgressSet::new(raft::default_logger()));
+        b.iter(|| ProgressTracker::new(raft::default_logger()));
     };
 
-    c.bench_function("ProgressSet::new", bench);
+    c.bench_function("ProgressTracker::new", bench);
 }
 
 pub fn bench_progress_set_with_capacity(c: &mut Criterion) {
     let bench = |voters, learners| {
         move |b: &mut Bencher| {
             // No setup.
-            b.iter(|| ProgressSet::with_capacity(voters, learners, raft::default_logger()));
+            b.iter(|| ProgressTracker::with_capacity(voters, learners, 10, raft::default_logger()));
         }
     };
 
     DEFAULT_RAFT_SETS.iter().for_each(|(voters, learners)| {
         c.bench_function(
-            &format!("ProgressSet::with_capacity ({}, {})", voters, learners),
+            &format!("ProgressTracker::with_capacity ({}, {})", voters, learners),
             bench(*voters, *learners),
         );
     });
@@ -66,7 +66,7 @@ pub fn bench_progress_set_insert_voter(c: &mut Criterion) {
 
     DEFAULT_RAFT_SETS.iter().for_each(|(voters, learners)| {
         c.bench_function(
-            &format!("ProgressSet::insert_voter ({}, {})", voters, learners),
+            &format!("ProgressTracker::insert_voter ({}, {})", voters, learners),
             bench(*voters, *learners),
         );
     });
@@ -85,7 +85,7 @@ pub fn bench_progress_set_insert_learner(c: &mut Criterion) {
 
     DEFAULT_RAFT_SETS.iter().for_each(|(voters, learners)| {
         c.bench_function(
-            &format!("ProgressSet::insert_learner ({}, {})", voters, learners),
+            &format!("ProgressTracker::insert_learner ({}, {})", voters, learners),
             bench(*voters, *learners),
         );
     });
@@ -104,7 +104,7 @@ pub fn bench_progress_set_remove(c: &mut Criterion) {
 
     DEFAULT_RAFT_SETS.iter().for_each(|(voters, learners)| {
         c.bench_function(
-            &format!("ProgressSet::remove ({}, {})", voters, learners),
+            &format!("ProgressTracker::remove ({}, {})", voters, learners),
             bench(*voters, *learners),
         );
     });
@@ -123,7 +123,7 @@ pub fn bench_progress_set_promote_learner(c: &mut Criterion) {
 
     DEFAULT_RAFT_SETS.iter().for_each(|(voters, learners)| {
         c.bench_function(
-            &format!("ProgressSet::promote ({}, {})", voters, learners),
+            &format!("ProgressTracker::promote ({}, {})", voters, learners),
             bench(*voters, *learners),
         );
     });
@@ -143,7 +143,7 @@ pub fn bench_progress_set_iter(c: &mut Criterion) {
 
     DEFAULT_RAFT_SETS.iter().for_each(|(voters, learners)| {
         c.bench_function(
-            &format!("ProgressSet::iter ({}, {})", voters, learners),
+            &format!("ProgressTracker::iter ({}, {})", voters, learners),
             bench(*voters, *learners),
         );
     });
@@ -166,7 +166,7 @@ pub fn bench_progress_set_voters(c: &mut Criterion) {
 
     DEFAULT_RAFT_SETS.iter().for_each(|(voters, learners)| {
         c.bench_function(
-            &format!("ProgressSet::nodes ({}, {})", voters, learners),
+            &format!("ProgressTracker::nodes ({}, {})", voters, learners),
             bench(*voters, *learners),
         );
     });
@@ -189,7 +189,7 @@ pub fn bench_progress_set_learners(c: &mut Criterion) {
 
     DEFAULT_RAFT_SETS.iter().for_each(|(voters, learners)| {
         c.bench_function(
-            &format!("ProgressSet::nodes ({}, {})", voters, learners),
+            &format!("ProgressTracker::nodes ({}, {})", voters, learners),
             bench(*voters, *learners),
         );
     });
@@ -210,7 +210,7 @@ pub fn bench_progress_set_get(c: &mut Criterion) {
 
     DEFAULT_RAFT_SETS.iter().for_each(|(voters, learners)| {
         c.bench_function(
-            &format!("ProgressSet::get ({}, {})", voters, learners),
+            &format!("ProgressTracker::get ({}, {})", voters, learners),
             bench(*voters, *learners),
         );
     });

--- a/benches/suites/progress_set.rs
+++ b/benches/suites/progress_set.rs
@@ -31,7 +31,7 @@ fn quick_progress_set(voters: usize, learners: usize) -> ProgressTracker {
 pub fn bench_progress_set_new(c: &mut Criterion) {
     let bench = |b: &mut Bencher| {
         // No setup.
-        b.iter(|| ProgressTracker::new(raft::default_logger()));
+        b.iter(|| ProgressTracker::new(256, raft::default_logger()));
     };
 
     c.bench_function("ProgressTracker::new", bench);

--- a/examples/five_mem_node/main.rs
+++ b/examples/five_mem_node/main.rs
@@ -296,7 +296,7 @@ fn on_ready(
                     ConfChangeType::RemoveNode => raft_group.raft.remove_node(node_id).unwrap(),
                     ConfChangeType::AddLearnerNode => raft_group.raft.add_learner(node_id).unwrap(),
                 }
-                let cs = raft_group.raft.prs().configuration().to_conf_state();
+                let cs = raft_group.raft.prs().conf().to_conf_state();
                 store.wl().set_conf_state(cs);
             } else {
                 // For normal proposals, extract the key-value pair and then

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -2929,7 +2929,7 @@ fn test_restore() {
         s.get_metadata().term
     );
     assert_eq!(
-        *sm.prs().voter_ids(),
+        sm.prs().voter_ids().iter().collect::<HashSet<_>>(),
         s.get_metadata()
             .get_conf_state()
             .voters
@@ -3143,7 +3143,7 @@ fn test_add_node() -> Result<()> {
     let mut r = new_test_raft(1, vec![1], 10, 1, new_storage(), &l);
     r.add_node(2)?;
     assert_eq!(
-        *r.prs().voter_ids(),
+        r.prs().voter_ids().iter().collect::<HashSet<_>>(),
         vec![1, 2].into_iter().collect::<HashSet<_>>()
     );
 
@@ -3190,7 +3190,7 @@ fn test_remove_node() -> Result<()> {
     let l = default_logger();
     let mut r = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     r.remove_node(2)?;
-    assert_eq!(r.prs().voter_ids().iter().next().unwrap(), &1);
+    assert_eq!(r.prs().voter_ids().iter().next().unwrap(), 1);
     // remove all nodes from cluster
     r.remove_node(1)?;
     assert!(r.prs().voter_ids().is_empty());
@@ -3203,7 +3203,7 @@ fn test_remove_node_itself() -> Result<()> {
     let l = default_logger().new(o!("test" => "remove_node_itself"));
     let mut n1 = new_test_learner_raft(1, vec![1], vec![2], 10, 1, new_storage(), &l);
     n1.remove_node(1)?;
-    assert_eq!(n1.prs().learner_ids().iter().next().unwrap(), &2);
+    assert_eq!(n1.prs().learner_ids().iter().next().unwrap(), 2);
     assert!(n1.prs().voter_ids().is_empty());
     Ok(())
 }
@@ -3235,9 +3235,9 @@ fn test_raft_nodes() {
     ];
     for (i, (ids, wids)) in tests.drain(..).enumerate() {
         let r = new_test_raft(1, ids, 10, 1, new_storage(), &l);
-        let voter_ids = r.prs().voter_ids();
+        let voter_ids: HashSet<_> = r.prs().voter_ids().iter().collect();
         let wids = wids.into_iter().collect::<HashSet<_>>();
-        if *voter_ids != wids {
+        if voter_ids != wids {
             panic!("#{}: nodes = {:?}, want {:?}", i, voter_ids, wids);
         }
     }
@@ -3918,12 +3918,12 @@ fn test_restore_with_learner() {
     let conf_state = s.get_metadata().get_conf_state();
     for &node in &conf_state.voters {
         assert!(sm.prs().get(node).is_some());
-        assert!(!sm.prs().learner_ids().contains(&node));
+        assert!(!sm.prs().learner_ids().contains(node));
     }
 
     for &node in &conf_state.learners {
         assert!(sm.prs().get(node).is_some());
-        assert!(sm.prs().learner_ids().contains(&node));
+        assert!(sm.prs().learner_ids().contains(node));
     }
 
     assert!(!sm.restore(s));
@@ -4011,8 +4011,8 @@ fn test_add_learner() -> Result<()> {
     let mut n1 = new_test_raft(1, vec![1], 10, 1, new_storage(), &l);
     n1.add_learner(2)?;
 
-    assert_eq!(*n1.prs().learner_ids().iter().next().unwrap(), 2);
-    assert!(n1.prs().learner_ids().contains(&2));
+    assert_eq!(n1.prs().learner_ids().iter().next().unwrap(), 2);
+    assert!(n1.prs().learner_ids().contains(2));
 
     Ok(())
 }
@@ -4027,11 +4027,11 @@ fn test_add_voter_peer_promotes_self_sets_is_learner() -> Result<()> {
     // Node is already voter.
     n1.add_learner(1).ok();
     assert!(n1.promotable());
-    assert!(n1.prs().voter_ids().contains(&1));
+    assert!(n1.prs().voter_ids().contains(1));
     n1.remove_node(1)?;
     n1.add_learner(1)?;
     assert!(!n1.promotable());
-    assert!(n1.prs().learner_ids().contains(&1));
+    assert!(n1.prs().learner_ids().contains(1));
 
     Ok(())
 }
@@ -4043,7 +4043,7 @@ fn test_remove_learner() -> Result<()> {
     let l = default_logger();
     let mut n1 = new_test_learner_raft(1, vec![1], vec![2], 10, 1, new_storage(), &l);
     n1.remove_node(2)?;
-    assert_eq!(n1.prs().voter_ids().iter().next().unwrap(), &1);
+    assert_eq!(n1.prs().voter_ids().iter().next().unwrap(), 1);
     assert!(n1.prs().learner_ids().is_empty());
 
     n1.remove_node(1)?;

--- a/harness/tests/integration_cases/test_raft_paper.rs
+++ b/harness/tests/integration_cases/test_raft_paper.rs
@@ -175,7 +175,7 @@ fn test_nonleader_start_election(state: StateRole, l: &Logger) {
 
     assert_eq!(r.term, 2);
     assert_eq!(r.state, StateRole::Candidate);
-    assert!(r.votes[&r.id]);
+    assert!(r.prs().votes()[&r.id]);
     let mut msgs = r.read_messages();
     msgs.sort_by_key(|m| format!("{:?}", m));
     let new_message_ext = |f, to| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -489,10 +489,11 @@ pub mod util;
 pub use self::config::Config;
 pub use self::errors::{Error, Result, StorageError};
 pub use self::log_unstable::Unstable;
+pub use self::quorum::joint::Configuration as JointConfig;
 pub use self::quorum::majority::Configuration as MajorityConfig;
 pub use self::raft::{vote_resp_msg_type, Raft, SoftState, StateRole, INVALID_ID, INVALID_INDEX};
 pub use self::raft_log::{RaftLog, NO_LIMIT};
-pub use self::tracker::{Inflights, Progress, ProgressSet, ProgressState};
+pub use self::tracker::{Inflights, Progress, ProgressState, ProgressTracker};
 
 #[allow(deprecated)]
 pub use self::raw_node::is_empty_snap;

--- a/src/quorum.rs
+++ b/src/quorum.rs
@@ -1,5 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
+pub mod joint;
 pub mod majority;
 
 use std::collections::HashMap;

--- a/src/quorum/joint.rs
+++ b/src/quorum/joint.rs
@@ -1,0 +1,80 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use super::{AckedIndexer, VoteResult};
+use crate::util::Union;
+use crate::HashSet;
+use crate::MajorityConfig;
+use std::cmp;
+
+/// A configuration of two groups of (possibly overlapping) majority configurations.
+/// Decisions require the support of both majorities.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Configuration {
+    pub(crate) incoming: MajorityConfig,
+    pub(crate) outgoing: MajorityConfig,
+}
+
+impl Configuration {
+    /// Creates a new configuration using the given IDs.
+    pub fn new(voters: HashSet<u64>) -> Configuration {
+        Configuration {
+            incoming: MajorityConfig::new(voters),
+            outgoing: MajorityConfig::default(),
+        }
+    }
+
+    /// Creates an empty configuration with given capacity.
+    pub fn with_capacity(cap: usize) -> Configuration {
+        Configuration {
+            incoming: MajorityConfig::with_capacity(cap),
+            outgoing: MajorityConfig::default(),
+        }
+    }
+
+    /// Returns the largest committed index for the given joint quorum. An index is
+    /// jointly committed if it is committed in both constituent majorities.
+    pub fn committed_index(&self, use_group_commit: bool, l: &impl AckedIndexer) -> (u64, bool) {
+        let i_idx = self.incoming.committed_index(use_group_commit, l);
+        let o_idx = self.outgoing.committed_index(use_group_commit, l);
+        (cmp::min(i_idx.0, o_idx.0), i_idx.1 && o_idx.1)
+    }
+
+    /// Takes a mapping of voters to yes/no (true/false) votes and returns a result
+    /// indicating whether the vote is pending, lost, or won. A joint quorum requires
+    /// both majority quorums to vote in favor.
+    pub fn vote_result(&self, check: impl Fn(u64) -> Option<bool>) -> VoteResult {
+        let i = self.incoming.vote_result(&check);
+        let o = self.outgoing.vote_result(check);
+        match (i, o) {
+            // It won if won in both.
+            (VoteResult::Won, VoteResult::Won) => VoteResult::Won,
+            // It lost if lost in either.
+            (VoteResult::Lost, _) | (_, VoteResult::Lost) => VoteResult::Lost,
+            // It remains pending if pending in both or just won in one side.
+            _ => VoteResult::Pending,
+        }
+    }
+
+    /// Clears all IDs.
+    pub fn clear(&mut self) {
+        self.incoming.clear();
+        self.outgoing.clear();
+    }
+
+    /// Returns true if (and only if) there is only one voting member
+    /// (i.e. the leader) in the current configuration.
+    pub fn is_singleton(&self) -> bool {
+        self.outgoing.voters.is_empty() && self.incoming.voters.len() == 1
+    }
+
+    /// Returns an iterator over two hash set without cloning.
+    pub fn ids(&self) -> Union<'_> {
+        Union::new(&self.incoming.voters, &self.outgoing.voters)
+    }
+
+    /// Check if an id is a voter.
+    #[inline]
+    pub fn contains(&self, id: u64) -> bool {
+        self.incoming.voters.contains(&id) || self.outgoing.voters.contains(&id)
+    }
+}

--- a/src/quorum/joint.rs
+++ b/src/quorum/joint.rs
@@ -33,6 +33,9 @@ impl Configuration {
 
     /// Returns the largest committed index for the given joint quorum. An index is
     /// jointly committed if it is committed in both constituent majorities.
+    ///
+    /// The bool flag indicates whether the index is computed by group commit algorithm
+    /// successfully. It's true only when both majorities use group commit.
     pub fn committed_index(&self, use_group_commit: bool, l: &impl AckedIndexer) -> (u64, bool) {
         let i_idx = self.incoming.committed_index(use_group_commit, l);
         let o_idx = self.outgoing.committed_index(use_group_commit, l);

--- a/src/quorum/joint.rs
+++ b/src/quorum/joint.rs
@@ -37,9 +37,9 @@ impl Configuration {
     /// The bool flag indicates whether the index is computed by group commit algorithm
     /// successfully. It's true only when both majorities use group commit.
     pub fn committed_index(&self, use_group_commit: bool, l: &impl AckedIndexer) -> (u64, bool) {
-        let i_idx = self.incoming.committed_index(use_group_commit, l);
-        let o_idx = self.outgoing.committed_index(use_group_commit, l);
-        (cmp::min(i_idx.0, o_idx.0), i_idx.1 && o_idx.1)
+        let (i_idx, i_use_gc) = self.incoming.committed_index(use_group_commit, l);
+        let (o_idx, o_use_gc) = self.outgoing.committed_index(use_group_commit, l);
+        (cmp::min(i_idx, o_idx), i_use_gc && o_use_gc)
     }
 
     /// Takes a mapping of voters to yes/no (true/false) votes and returns a result

--- a/src/quorum/majority.rs
+++ b/src/quorum/majority.rs
@@ -26,9 +26,14 @@ impl Configuration {
 
     /// Returns the MajorityConfig as a sorted slice.
     pub fn slice(&self) -> Vec<u64> {
-        let mut voters: Vec<_> = self.voters.iter().cloned().collect();
+        let mut voters = self.raw_slice();
         voters.sort();
         voters
+    }
+
+    /// Returns the MajorityConfig as a slice.
+    pub fn raw_slice(&self) -> Vec<u64> {
+        self.voters.iter().cloned().collect()
     }
 
     /// Computes the committed index from those supplied via the
@@ -43,7 +48,7 @@ impl Configuration {
         if self.voters.is_empty() {
             // This plays well with joint quorums which, when one half is the zero
             // MajorityConfig, should behave like the other half.
-            return (u64::MAX, false);
+            return (u64::MAX, true);
         }
 
         let mut stack_arr: [MaybeUninit<Index>; 7] = unsafe { MaybeUninit::uninit().assume_init() };

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1066,7 +1066,7 @@ impl<T: Storage> Raft<T> {
                 continue;
             }
 
-            if voter_cnt == 7 {
+            if voter_cnt == voters.len() {
                 self.log_broadcast_vote(vote_msg, &voters);
                 voter_cnt = 0;
             }

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -27,8 +27,8 @@ use super::read_only::{ReadOnly, ReadOnlyOption, ReadState};
 use super::storage::Storage;
 use super::Config;
 use crate::quorum::VoteResult;
-use crate::{util, HashMap, HashSet};
-use crate::{Progress, ProgressSet, ProgressState};
+use crate::util;
+use crate::{Progress, ProgressState, ProgressTracker};
 
 // CAMPAIGN_PRE_ELECTION represents the first phase of a normal election when
 // Config.pre_vote is true.
@@ -110,11 +110,6 @@ pub struct RaftCore<T: Storage> {
     /// which is true when it's a voter and its own id is in progress list.
     promotable: bool,
 
-    /// The current votes for this node in an election.
-    ///
-    /// Reset when changing role.
-    pub votes: HashMap<u64, bool>,
-
     /// The leader id
     pub leader_id: u64,
 
@@ -181,7 +176,7 @@ pub struct RaftCore<T: Storage> {
 /// A struct that represents the raft consensus itself. Stores details concerning the current
 /// and possible state the system can take.
 pub struct Raft<T: Storage> {
-    prs: ProgressSet,
+    prs: ProgressTracker,
 
     /// The list of messages.
     pub msgs: Vec<Message>,
@@ -240,7 +235,12 @@ impl<T: Storage> Raft<T> {
         let learners = &conf_state.learners;
 
         let mut r = Raft {
-            prs: ProgressSet::with_capacity(voters.len(), learners.len(), logger.clone()),
+            prs: ProgressTracker::with_capacity(
+                voters.len(),
+                learners.len(),
+                c.max_inflight_msgs,
+                logger.clone(),
+            ),
             msgs: Default::default(),
             r: RaftCore {
                 id: c.id,
@@ -256,7 +256,6 @@ impl<T: Storage> Raft<T> {
                 read_only: ReadOnly::new(c.read_only_option),
                 heartbeat_timeout: c.heartbeat_tick,
                 election_timeout: c.election_tick,
-                votes: Default::default(),
                 leader_id: Default::default(),
                 lead_transferee: None,
                 term: Default::default(),
@@ -833,7 +832,7 @@ impl<T: Storage> Raft<T> {
 
         self.abort_leader_transfer();
 
-        self.votes.clear();
+        self.prs.reset_votes();
 
         self.pending_conf_index = 0;
         self.read_only = ReadOnly::new(self.read_only.option);
@@ -980,7 +979,7 @@ impl<T: Storage> Raft<T> {
         // but doesn't change anything else. In particular it does not increase
         // self.term or change self.vote.
         self.state = StateRole::PreCandidate;
-        self.votes = HashMap::default();
+        self.prs.reset_votes();
         // If a network partition happens, and leader is in minority partition,
         // it will step down, and become follower without notifying others.
         self.leader_id = INVALID_ID;
@@ -1052,37 +1051,29 @@ impl<T: Storage> Raft<T> {
             (MessageType::MsgRequestVote, self.term)
         };
         let self_id = self.id;
-        let acceptance = true;
-        info!(
-            self.logger,
-            "{id} received message from {from}",
-            id = self.id,
-            from = self_id;
-            "msg" => ?vote_msg,
-            "term" => self.term
-        );
-        self.register_vote(self_id, acceptance);
-        if let Some(true) = self.check_votes() {
+        if let Some(true) = self.poll(self_id, vote_msg, true) {
             // We won the election after voting for ourselves (which must mean that
             // this is a single-node cluster).
             return;
         }
 
+        let mut voters = [0; 7];
+        let mut voter_cnt = 0;
+
         // Only send vote request to voters.
-        for id in self.prs.voter_ids() {
-            if *id == self_id {
+        for id in self.prs.voter_ids().iter() {
+            if id == self_id {
                 continue;
             }
-            info!(
-                self.logger,
-                "[logterm: {log_term}, index: {log_index}] sent request to {id}",
-                log_term = self.raft_log.last_term(),
-                log_index = self.raft_log.last_index(),
-                id = id;
-                "term" => self.term,
-                "msg" => ?vote_msg,
-            );
-            let mut m = new_message(*id, vote_msg, None);
+
+            if voter_cnt < 7 {
+                voters[voter_cnt] = id;
+                voter_cnt += 1;
+            } else {
+                self.log_broadcast_vote(vote_msg, &voters);
+                voter_cnt = 0;
+            }
+            let mut m = new_message(id, vote_msg, None);
             m.term = term;
             m.index = self.raft_log.last_index();
             m.log_term = self.raft_log.last_term();
@@ -1091,11 +1082,22 @@ impl<T: Storage> Raft<T> {
             }
             self.r.send(m, &mut self.msgs);
         }
+        if voter_cnt > 0 {
+            self.log_broadcast_vote(vote_msg, &voters[..voter_cnt]);
+        }
     }
 
-    /// Sets the vote of `id` to `vote`.
-    fn register_vote(&mut self, id: u64, vote: bool) {
-        self.votes.entry(id).or_insert(vote);
+    #[inline]
+    fn log_broadcast_vote(&self, t: MessageType, ids: &[u64]) {
+        info!(
+            self.logger,
+            "broadcasting vote request";
+            "type" => ?t,
+            "term" => self.term,
+            "log_term" => self.raft_log.last_term(),
+            "log_index" => self.raft_log.last_index(),
+            "to" => ?ids,
+        );
     }
 
     /// Steps the raft along via a message. This should be called everytime your raft receives a
@@ -1524,7 +1526,7 @@ impl<T: Storage> Raft<T> {
         }
 
         let from = m.from;
-        if self.prs.learner_ids().contains(&from) {
+        if self.prs.learner_ids().contains(from) {
             debug!(
                 self.logger,
                 "ignored transferring leadership";
@@ -1669,7 +1671,7 @@ impl<T: Storage> Raft<T> {
                 if m.entries.is_empty() {
                     fatal!(self.logger, "stepped empty MsgProp");
                 }
-                if !self.prs().voter_ids().contains(&self.id) {
+                if !self.prs().voter_ids().contains(self.id) {
                     // If we are not currently a member of the range (i.e. this node
                     // was removed from the configuration while serving as leader),
                     // drop any new proposals.
@@ -1714,32 +1716,31 @@ impl<T: Storage> Raft<T> {
                     return Ok(());
                 }
 
-                let mut self_set = HashSet::default();
-                self_set.insert(self.id);
-                if !self.prs().has_quorum(&self_set) {
-                    // thinking: use an interally defined context instead of the user given context.
-                    // We can express this in terms of the term and index instead of
-                    // a user-supplied value.
-                    // This would allow multiple reads to piggyback on the same message.
-                    match self.read_only.option {
-                        ReadOnlyOption::Safe => {
-                            let ctx = m.entries[0].data.to_vec();
-                            self.r
-                                .read_only
-                                .add_request(self.r.raft_log.committed, m, self.r.id);
-                            self.bcast_heartbeat_with_ctx(Some(ctx));
-                        }
-                        ReadOnlyOption::LeaseBased => {
-                            let read_index = self.raft_log.committed;
-                            if let Some(m) = self.handle_ready_read_index(m, read_index) {
-                                self.r.send(m, &mut self.msgs);
-                            }
-                        }
-                    }
-                } else {
+                if self.prs().is_singleton() {
                     let read_index = self.raft_log.committed;
                     if let Some(m) = self.handle_ready_read_index(m, read_index) {
                         self.r.send(m, &mut self.msgs);
+                    }
+                    return Ok(());
+                }
+
+                // thinking: use an interally defined context instead of the user given context.
+                // We can express this in terms of the term and index instead of
+                // a user-supplied value.
+                // This would allow multiple reads to piggyback on the same message.
+                match self.read_only.option {
+                    ReadOnlyOption::Safe => {
+                        let ctx = m.entries[0].data.to_vec();
+                        self.r
+                            .read_only
+                            .add_request(self.r.raft_log.committed, m, self.r.id);
+                        self.bcast_heartbeat_with_ctx(Some(ctx));
+                    }
+                    ReadOnlyOption::LeaseBased => {
+                        let read_index = self.raft_log.committed;
+                        if let Some(m) = self.handle_ready_read_index(m, read_index) {
+                            self.r.send(m, &mut self.msgs);
+                        }
                     }
                 }
                 return Ok(());
@@ -1777,9 +1778,22 @@ impl<T: Storage> Raft<T> {
         Ok(())
     }
 
-    /// Check if it can become leader.
-    fn check_votes(&mut self) -> Option<bool> {
-        match self.prs().vote_result(&self.votes) {
+    fn poll(&mut self, from: u64, t: MessageType, vote: bool) -> Option<bool> {
+        // Unlike etcd, we only log final result to reduce log records.
+        self.prs.record_vote(from, vote);
+        let (gr, rj, res) = self.prs.tally_votes();
+        info!(
+            self.logger,
+            "received votes response";
+            "vote" => vote,
+            "from" => from,
+            "rejections" => rj,
+            "approvals" => gr,
+            "msg type" => ?t,
+            "term" => self.term,
+        );
+
+        match res {
             VoteResult::Won => {
                 if self.state == StateRole::PreCandidate {
                     self.campaign(CAMPAIGN_ELECTION);
@@ -1839,18 +1853,7 @@ impl<T: Storage> Raft<T> {
                     return Ok(());
                 }
 
-                let acceptance = !m.reject;
-                let from_id = m.from;
-                info!(
-                    self.logger,
-                    "received{} from {from}",
-                    if !acceptance { " rejection" } else { "" },
-                    from = from_id;
-                    "msg type" => ?m.get_msg_type(),
-                    "term" => self.term,
-                );
-                self.register_vote(from_id, acceptance);
-                self.check_votes();
+                self.poll(m.from, m.get_msg_type(), !m.reject);
             }
             MessageType::MsgTimeoutNow => debug!(
                 self.logger,
@@ -2143,9 +2146,9 @@ impl<T: Storage> Raft<T> {
         let next_idx = self.raft_log.last_index() + 1;
         self.prs.restore_snapmeta(meta, next_idx, self.max_inflight);
         self.prs.get_mut(self.id).unwrap().matched = next_idx - 1;
-        if self.prs.voter_ids().contains(&self.id) {
+        if self.prs.voter_ids().contains(self.id) {
             self.promotable = true;
-        } else if self.prs.learner_ids().contains(&self.id) {
+        } else if self.prs.learner_ids().contains(self.id) {
             self.promotable = false;
         }
 
@@ -2201,7 +2204,7 @@ impl<T: Storage> Raft<T> {
         let result = if learner {
             let progress = Progress::new(self.raft_log.last_index() + 1, self.max_inflight);
             self.mut_prs().insert_learner(id, progress)
-        } else if self.prs().learner_ids().contains(&id) {
+        } else if self.prs().learner_ids().contains(id) {
             self.mut_prs().promote_learner(id)
         } else {
             let progress = Progress::new(self.raft_log.last_index() + 1, self.max_inflight);
@@ -2301,12 +2304,12 @@ impl<T: Storage> Raft<T> {
     }
 
     /// Returns a read-only reference to the progress set.
-    pub fn prs(&self) -> &ProgressSet {
+    pub fn prs(&self) -> &ProgressTracker {
         &self.prs
     }
 
     /// Returns a mutable reference to the progress set.
-    pub fn mut_prs(&mut self) -> &mut ProgressSet {
+    pub fn mut_prs(&mut self) -> &mut ProgressTracker {
         &mut self.prs
     }
 

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1779,19 +1779,21 @@ impl<T: Storage> Raft<T> {
     }
 
     fn poll(&mut self, from: u64, t: MessageType, vote: bool) -> Option<bool> {
-        // Unlike etcd, we only log final result to reduce log records.
         self.prs.record_vote(from, vote);
         let (gr, rj, res) = self.prs.tally_votes();
-        info!(
-            self.logger,
-            "received votes response";
-            "vote" => vote,
-            "from" => from,
-            "rejections" => rj,
-            "approvals" => gr,
-            "msg type" => ?t,
-            "term" => self.term,
-        );
+        // Unlike etcd, we log when necessary.
+        if from != self.id {
+            info!(
+                self.logger,
+                "received votes response";
+                "vote" => vote,
+                "from" => from,
+                "rejections" => rj,
+                "approvals" => gr,
+                "msg type" => ?t,
+                "term" => self.term,
+            );
+        }
 
         match res {
             VoteResult::Won => {

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1066,13 +1066,12 @@ impl<T: Storage> Raft<T> {
                 continue;
             }
 
-            if voter_cnt < 7 {
-                voters[voter_cnt] = id;
-                voter_cnt += 1;
-            } else {
+            if voter_cnt == 7 {
                 self.log_broadcast_vote(vote_msg, &voters);
                 voter_cnt = 0;
             }
+            voters[voter_cnt] = id;
+            voter_cnt += 1;
             let mut m = new_message(id, vote_msg, None);
             m.term = term;
             m.index = self.raft_log.last_index();

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -321,10 +321,7 @@ impl<T: Storage> RawNode<T> {
     /// Takes the conf change and applies it.
     pub fn apply_conf_change(&mut self, cc: &ConfChange) -> Result<ConfState> {
         if cc.node_id == INVALID_ID {
-            let mut cs = ConfState::default();
-            cs.voters = self.raft.prs().voter_ids().iter().cloned().collect();
-            cs.learners = self.raft.prs().learner_ids().iter().cloned().collect();
-            return Ok(cs);
+            return Ok(self.raft.prs().conf().to_conf_state());
         }
         let nid = cc.node_id;
         match cc.get_change_type() {
@@ -333,7 +330,7 @@ impl<T: Storage> RawNode<T> {
             ConfChangeType::RemoveNode => self.raft.remove_node(nid)?,
         };
 
-        Ok(self.raft.prs().configuration().to_conf_state())
+        Ok(self.raft.prs().conf().to_conf_state())
     }
 
     /// Step advances the state machine using the given message.

--- a/src/status.rs
+++ b/src/status.rs
@@ -18,7 +18,7 @@ use crate::eraftpb::HardState;
 
 use crate::raft::{Raft, SoftState, StateRole};
 use crate::storage::Storage;
-use crate::ProgressSet;
+use crate::ProgressTracker;
 
 /// Represents the current status of the raft
 #[derive(Default)]
@@ -32,7 +32,7 @@ pub struct Status<'a> {
     /// The index of the last entry to have been applied.
     pub applied: u64,
     /// The progress towards catching up and applying logs.
-    pub progress: Option<&'a ProgressSet>,
+    pub progress: Option<&'a ProgressTracker>,
 }
 
 impl<'a> Status<'a> {

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -80,7 +80,7 @@ pub struct Configuration {
     /// right away when entering the joint configuration, so that it is caught up
     /// as soon as possible.
     #[get = "pub"]
-    learner_next: HashSet<u64>,
+    learners_next: HashSet<u64>,
     /// True if the configuration is joint and a transition to the incoming
     /// configuration should be carried out automatically by Raft when this is
     /// possible. If false, the configuration will be joint until the application
@@ -98,7 +98,7 @@ impl Configuration {
             voters: JointConfig::new(voters.into_iter().collect()),
             auto_leave: false,
             learners: learners.into_iter().collect(),
-            learner_next: HashSet::default(),
+            learners_next: HashSet::default(),
         }
     }
 
@@ -106,7 +106,7 @@ impl Configuration {
         Self {
             voters: JointConfig::with_capacity(voters),
             learners: HashSet::with_capacity_and_hasher(learners, DefaultHashBuilder::default()),
-            learner_next: HashSet::default(),
+            learners_next: HashSet::default(),
             auto_leave: false,
         }
     }
@@ -118,7 +118,7 @@ impl Configuration {
         state.set_voters(self.voters.incoming.raw_slice());
         state.set_voters_outgoing(self.voters.outgoing.raw_slice());
         state.set_learners(self.learners.iter().cloned().collect());
-        state.set_learners_next(self.learner_next.iter().cloned().collect());
+        state.set_learners_next(self.learners_next.iter().cloned().collect());
         state.auto_leave = self.auto_leave;
         state
     }
@@ -259,7 +259,7 @@ impl ProgressTracker {
     /// transitioning to a new configuration and have two qourums. Use `has_quorum` instead.
     #[inline]
     pub fn learners_mut(&mut self) -> impl Iterator<Item = (&u64, &mut Progress)> {
-        let ids = Union::new(&self.conf.learners, &self.conf.learner_next);
+        let ids = Union::new(&self.conf.learners, &self.conf.learners_next);
         self.progress
             .iter_mut()
             .filter(move |(k, _)| ids.contains(**k))
@@ -280,7 +280,7 @@ impl ProgressTracker {
     /// transitioning to a new configuration and have two qourums. Use `has_quorum` instead.
     #[inline]
     pub fn learner_ids(&self) -> Union<'_> {
-        Union::new(&self.conf.learners, &self.conf.learner_next)
+        Union::new(&self.conf.learners, &self.conf.learners_next)
     }
 
     /// Grabs a reference to the progress of a node.

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -27,13 +27,14 @@ use slog::Logger;
 use crate::eraftpb::{ConfState, SnapshotMetadata};
 use crate::errors::{Error, Result};
 use crate::quorum::{AckedIndexer, Index, VoteResult};
-use crate::{DefaultHashBuilder, HashMap, HashSet, MajorityConfig};
+use crate::util::Union;
+use crate::{DefaultHashBuilder, HashMap, HashSet, JointConfig};
 
 /// Config reflects the configuration tracked in a ProgressTracker.
 #[derive(Clone, Debug, Default, PartialEq, Getters)]
 pub struct Configuration {
     #[get = "pub"]
-    voters: MajorityConfig,
+    voters: JointConfig,
     /// Learners is a set of IDs corresponding to the learners active in the
     /// current configuration.
     ///
@@ -44,6 +45,47 @@ pub struct Configuration {
     /// its current role without taking into account joint consensus.
     #[get = "pub"]
     learners: HashSet<u64>,
+    /// When we turn a voter into a learner during a joint consensus transition,
+    /// we cannot add the learner directly when entering the joint state. This is
+    /// because this would violate the invariant that the intersection of
+    /// voters and learners is empty. For example, assume a Voter is removed and
+    /// immediately re-added as a learner (or in other words, it is demoted):
+    ///
+    /// Initially, the configuration will be
+    ///
+    ///   voters:   {1 2 3}
+    ///   learners: {}
+    ///
+    /// and we want to demote 3. Entering the joint configuration, we naively get
+    ///
+    ///   voters:   {1 2} & {1 2 3}
+    ///   learners: {3}
+    ///
+    /// but this violates the invariant (3 is both voter and learner). Instead,
+    /// we get
+    ///
+    ///   voters:   {1 2} & {1 2 3}
+    ///   learners: {}
+    ///   next_learners: {3}
+    ///
+    /// Where 3 is now still purely a voter, but we are remembering the intention
+    /// to make it a learner upon transitioning into the final configuration:
+    ///
+    ///   voters:   {1 2}
+    ///   learners: {3}
+    ///   next_learners: {}
+    ///
+    /// Note that next_learners is not used while adding a learner that is not
+    /// also a voter in the joint config. In this case, the learner is added
+    /// right away when entering the joint configuration, so that it is caught up
+    /// as soon as possible.
+    #[get = "pub"]
+    learner_next: HashSet<u64>,
+    /// True if the configuration is joint and a transition to the incoming
+    /// configuration should be carried out automatically by Raft when this is
+    /// possible. If false, the configuration will be joint until the application
+    /// initiates the transition manually.
+    auto_leave: bool,
 }
 
 impl Configuration {
@@ -53,47 +95,32 @@ impl Configuration {
         learners: impl IntoIterator<Item = u64>,
     ) -> Self {
         Self {
-            voters: MajorityConfig::new(voters.into_iter().collect()),
+            voters: JointConfig::new(voters.into_iter().collect()),
+            auto_leave: false,
             learners: learners.into_iter().collect(),
+            learner_next: HashSet::default(),
+        }
+    }
+
+    fn with_capacity(voters: usize, learners: usize) -> Self {
+        Self {
+            voters: JointConfig::with_capacity(voters),
+            learners: HashSet::with_capacity_and_hasher(learners, DefaultHashBuilder::default()),
+            learner_next: HashSet::default(),
+            auto_leave: false,
         }
     }
 
     /// Create a new `ConfState` from the configuration itself.
     pub fn to_conf_state(&self) -> ConfState {
+        // Note: Different from etcd, we don't sort.
         let mut state = ConfState::default();
-        state.set_voters(self.voters.voters.iter().cloned().collect());
+        state.set_voters(self.voters.incoming.raw_slice());
+        state.set_voters_outgoing(self.voters.outgoing.raw_slice());
         state.set_learners(self.learners.iter().cloned().collect());
+        state.set_learners_next(self.learner_next.iter().cloned().collect());
+        state.auto_leave = self.auto_leave;
         state
-    }
-
-    /// Create a new `Configuration` from a given `ConfState`.
-    pub fn from_conf_state(conf_state: &ConfState) -> Self {
-        Self {
-            voters: MajorityConfig::new(conf_state.voters.iter().cloned().collect()),
-            learners: conf_state.learners.iter().cloned().collect(),
-        }
-    }
-}
-
-impl<Iter1, Iter2> From<(Iter1, Iter2)> for Configuration
-where
-    Iter1: IntoIterator<Item = u64>,
-    Iter2: IntoIterator<Item = u64>,
-{
-    fn from((voters, learners): (Iter1, Iter2)) -> Self {
-        Self {
-            voters: MajorityConfig::new(voters.into_iter().collect()),
-            learners: learners.into_iter().collect(),
-        }
-    }
-}
-
-impl Configuration {
-    fn with_capacity(voters: usize, learners: usize) -> Self {
-        Self {
-            voters: MajorityConfig::with_capacity(voters),
-            learners: HashSet::with_capacity_and_hasher(learners, DefaultHashBuilder::default()),
-        }
     }
 }
 
@@ -106,34 +133,46 @@ impl AckedIndexer for HashMap<u64, Progress> {
     }
 }
 
-/// `ProgressSet` contains several `Progress`es,
+/// `ProgressTracker` contains several `Progress`es,
 /// which could be `Leader`, `Follower` and `Learner`.
 #[derive(Clone, Getters)]
-pub struct ProgressSet {
+pub struct ProgressTracker {
     progress: HashMap<u64, Progress>,
 
     /// The current configuration state of the cluster.
     #[get = "pub"]
-    configuration: Configuration,
+    conf: Configuration,
+    #[doc(hidden)]
+    #[get = "pub"]
+    votes: HashMap<u64, bool>,
+    #[get = "pub(crate)"]
+    max_inflight: usize,
 
     group_commit: bool,
     pub(crate) logger: Logger,
 }
 
-impl ProgressSet {
-    /// Creates a new ProgressSet.
-    pub fn new(logger: Logger) -> Self {
-        Self::with_capacity(0, 0, logger)
+impl ProgressTracker {
+    /// Creates a new ProgressTracker.
+    pub fn new(max_inflight: usize, logger: Logger) -> Self {
+        Self::with_capacity(0, 0, max_inflight, logger)
     }
 
     /// Create a progress set with the specified sizes already reserved.
-    pub fn with_capacity(voters: usize, learners: usize, logger: Logger) -> Self {
-        ProgressSet {
+    pub fn with_capacity(
+        voters: usize,
+        learners: usize,
+        max_inflight: usize,
+        logger: Logger,
+    ) -> Self {
+        ProgressTracker {
             progress: HashMap::with_capacity_and_hasher(
                 voters + learners,
                 DefaultHashBuilder::default(),
             ),
-            configuration: Configuration::with_capacity(voters, learners),
+            conf: Configuration::with_capacity(voters, learners),
+            votes: HashMap::with_capacity_and_hasher(voters, DefaultHashBuilder::default()),
+            max_inflight,
             group_commit: false,
             logger,
         }
@@ -151,8 +190,14 @@ impl ProgressSet {
 
     fn clear(&mut self) {
         self.progress.clear();
-        self.configuration.voters.clear();
-        self.configuration.learners.clear();
+        self.conf.voters.clear();
+        self.conf.learners.clear();
+    }
+
+    /// Returns true if (and only if) there is only one voting member
+    /// (i.e. the leader) in the current configuration.
+    pub fn is_singleton(&self) -> bool {
+        self.conf.voters.is_singleton()
     }
 
     pub(crate) fn restore_snapmeta(
@@ -165,11 +210,12 @@ impl ProgressSet {
         let pr = Progress::new(next_idx, max_inflight);
         for id in &meta.conf_state.as_ref().unwrap().voters {
             self.progress.insert(*id, pr.clone());
-            self.configuration.voters.voters.insert(*id);
+            // TODO: use conf_change package to update ProgressTracker.
+            self.conf.voters.incoming.voters.insert(*id);
         }
         for id in &meta.conf_state.as_ref().unwrap().learners {
             self.progress.insert(*id, pr.clone());
-            self.configuration.learners.insert(*id);
+            self.conf.learners.insert(*id);
         }
 
         self.assert_progress_and_configuration_consistent();
@@ -182,7 +228,7 @@ impl ProgressSet {
     #[inline]
     pub fn voters(&self) -> impl Iterator<Item = (&u64, &Progress)> {
         let set = self.voter_ids();
-        self.progress.iter().filter(move |(&k, _)| set.contains(&k))
+        self.progress.iter().filter(move |(k, _)| set.contains(**k))
     }
 
     /// Returns the status of learners.
@@ -192,7 +238,7 @@ impl ProgressSet {
     #[inline]
     pub fn learners(&self) -> impl Iterator<Item = (&u64, &Progress)> {
         let set = self.learner_ids();
-        self.progress.iter().filter(move |(&k, _)| set.contains(&k))
+        self.progress.iter().filter(move |(k, _)| set.contains(**k))
     }
 
     /// Returns the mutable status of voters.
@@ -201,10 +247,10 @@ impl ProgressSet {
     /// transitioning to a new configuration and have two qourums. Use `has_quorum` instead.
     #[inline]
     pub fn voters_mut(&mut self) -> impl Iterator<Item = (&u64, &mut Progress)> {
-        let ids = &self.configuration.voters.voters;
+        let ids = &self.conf.voters;
         self.progress
             .iter_mut()
-            .filter(move |(k, _)| ids.contains(k))
+            .filter(move |(k, _)| ids.contains(**k))
     }
 
     /// Returns the mutable status of learners.
@@ -213,10 +259,10 @@ impl ProgressSet {
     /// transitioning to a new configuration and have two qourums. Use `has_quorum` instead.
     #[inline]
     pub fn learners_mut(&mut self) -> impl Iterator<Item = (&u64, &mut Progress)> {
-        let ids = &self.configuration.learners;
+        let ids = Union::new(&self.conf.learners, &self.conf.learner_next);
         self.progress
             .iter_mut()
-            .filter(move |(k, _)| ids.contains(k))
+            .filter(move |(k, _)| ids.contains(**k))
     }
 
     /// Returns the ids of all known voters.
@@ -224,8 +270,8 @@ impl ProgressSet {
     /// **Note:** Do not use this for majority/quorum calculation. The Raft node may be
     /// transitioning to a new configuration and have two qourums. Use `has_quorum` instead.
     #[inline]
-    pub fn voter_ids(&self) -> &HashSet<u64> {
-        &self.configuration.voters.voters
+    pub fn voter_ids(&self) -> Union<'_> {
+        self.conf.voters.ids()
     }
 
     /// Returns the ids of all known learners.
@@ -233,8 +279,8 @@ impl ProgressSet {
     /// **Note:** Do not use this for majority/quorum calculation. The Raft node may be
     /// transitioning to a new configuration and have two qourums. Use `has_quorum` instead.
     #[inline]
-    pub fn learner_ids(&self) -> &HashSet<u64> {
-        &self.configuration.learners
+    pub fn learner_ids(&self) -> Union<'_> {
+        Union::new(&self.conf.learners, &self.conf.learner_next)
     }
 
     /// Grabs a reference to the progress of a node.
@@ -276,13 +322,14 @@ impl ProgressSet {
     pub fn insert_voter(&mut self, id: u64, pr: Progress) -> Result<()> {
         debug!(self.logger, "Inserting voter with id {id}", id = id);
 
-        if self.learner_ids().contains(&id) {
+        if self.learner_ids().contains(id) {
             return Err(Error::Exists(id, "learners"));
-        } else if self.voter_ids().contains(&id) {
+        } else if self.voter_ids().contains(id) {
             return Err(Error::Exists(id, "voters"));
         }
 
-        self.configuration.voters.voters.insert(id);
+        // TODO: use conf change to update configuration.
+        self.conf.voters.incoming.voters.insert(id);
         self.progress.insert(id, pr);
         self.assert_progress_and_configuration_consistent();
         Ok(())
@@ -297,13 +344,13 @@ impl ProgressSet {
     pub fn insert_learner(&mut self, id: u64, pr: Progress) -> Result<()> {
         debug!(self.logger, "Inserting learner with id {id}", id = id);
 
-        if self.learner_ids().contains(&id) {
+        if self.learner_ids().contains(id) {
             return Err(Error::Exists(id, "learners"));
-        } else if self.voter_ids().contains(&id) {
+        } else if self.voter_ids().contains(id) {
             return Err(Error::Exists(id, "voters"));
         }
 
-        self.configuration.learners.insert(id);
+        self.conf.learners.insert(id);
         self.progress.insert(id, pr);
         self.assert_progress_and_configuration_consistent();
         Ok(())
@@ -315,8 +362,8 @@ impl ProgressSet {
     ///
     pub fn remove(&mut self, id: u64) -> Result<Option<Progress>> {
         debug!(self.logger, "Removing peer with id {id}", id = id);
-        self.configuration.learners.remove(&id);
-        self.configuration.voters.voters.remove(&id);
+        self.conf.learners.remove(&id);
+        self.conf.voters.incoming.voters.remove(&id);
         let removed = self.progress.remove(&id);
 
         self.assert_progress_and_configuration_consistent();
@@ -327,11 +374,11 @@ impl ProgressSet {
     pub fn promote_learner(&mut self, id: u64) -> Result<()> {
         debug!(self.logger, "Promoting peer with id {id}", id = id);
 
-        if !self.configuration.learners.remove(&id) {
+        if !self.conf.learners.remove(&id) {
             // Wasn't already a learner. We can't promote what doesn't exist.
             return Err(Error::NotExists(id, "learners"));
         }
-        if !self.configuration.voters.voters.insert(id) {
+        if !self.conf.voters.incoming.voters.insert(id) {
             // Already existed, the caller should know this was a noop.
             return Err(Error::Exists(id, "voters"));
         }
@@ -343,15 +390,12 @@ impl ProgressSet {
     #[inline(always)]
     fn assert_progress_and_configuration_consistent(&self) {
         debug_assert!(self
-            .configuration
+            .conf
             .voters
+            .incoming
             .voters
-            .union(&self.configuration.learners)
+            .union(&self.conf.learners)
             .all(|v| self.progress.contains_key(v)));
-        assert_eq!(
-            self.voter_ids().len() + self.learner_ids().len(),
-            self.progress.len()
-        );
     }
 
     /// Returns the maximal committed index for the cluster. The bool flag indicates whether
@@ -360,9 +404,42 @@ impl ProgressSet {
     /// Eg. If the matched indexes are [2,2,2,4,5], it will return 2.
     /// If the matched indexes and groups are `[(1, 1), (2, 2), (3, 2)]`, it will return 1.
     pub fn maximal_committed_index(&mut self) -> (u64, bool) {
-        self.configuration
+        self.conf
             .voters
             .committed_index(self.group_commit, &self.progress)
+    }
+
+    /// Prepares for a new round of vote counting via recordVote.
+    pub fn reset_votes(&mut self) {
+        self.votes.clear();
+    }
+
+    /// Records that the node with the given id voted for this Raft
+    /// instance if v == true (and declined it otherwise).
+    pub fn record_vote(&mut self, id: u64, vote: bool) {
+        self.votes.entry(id).or_insert(vote);
+    }
+
+    /// TallyVotes returns the number of granted and rejected Votes, and whether the
+    /// election outcome is known.
+    pub fn tally_votes(&self) -> (usize, usize, VoteResult) {
+        // Make sure to populate granted/rejected correctly even if the Votes slice
+        // contains members no longer part of the configuration. This doesn't really
+        // matter in the way the numbers are used (they're informational), but might
+        // as well get it right.
+        let (mut granted, mut rejected) = (0, 0);
+        for (id, vote) in &self.votes {
+            if !self.conf.voters.contains(*id) {
+                continue;
+            }
+            if *vote {
+                granted += 1;
+            } else {
+                rejected += 1;
+            }
+        }
+        let result = self.vote_result(&self.votes);
+        (granted, rejected, result)
     }
 
     /// Returns the Candidate's eligibility in the current election.
@@ -371,9 +448,7 @@ impl ProgressSet {
     /// Eventually, the election will result in this returning either `Elected`
     /// or `Ineligible`, meaning the election can be concluded.
     pub fn vote_result(&self, votes: &HashMap<u64, bool>) -> VoteResult {
-        self.configuration
-            .voters
-            .vote_result(|id| votes.get(&id).cloned())
+        self.conf.voters.vote_result(|id| votes.get(&id).cloned())
     }
 
     /// Determines if the current quorum is active according to the this raft node.
@@ -399,7 +474,7 @@ impl ProgressSet {
     /// This is the only correct way to verify you have reached a quorum for the whole group.
     #[inline]
     pub fn has_quorum(&self, potential_quorum: &HashSet<u64>) -> bool {
-        self.configuration
+        self.conf
             .voters
             .vote_result(|id| potential_quorum.get(&id).map(|_| true))
             == VoteResult::Won
@@ -410,7 +485,7 @@ impl ProgressSet {
 // See https://github.com/pingcap/raft-rs/issues/125
 #[cfg(test)]
 mod test_progress_set {
-    use super::{ProgressSet, Result};
+    use super::{ProgressTracker, Result};
     use crate::default_logger;
     use crate::Progress;
 
@@ -418,7 +493,7 @@ mod test_progress_set {
 
     #[test]
     fn test_insert_redundant_voter() -> Result<()> {
-        let mut set = ProgressSet::new(default_logger());
+        let mut set = ProgressTracker::new(256, default_logger());
         let default_progress = Progress::new(0, 256);
         let mut canary_progress = Progress::new(0, 256);
         canary_progress.matched = CANARY;
@@ -430,14 +505,14 @@ mod test_progress_set {
         assert_eq!(
             *set.get(1).expect("Should be inserted."),
             default_progress,
-            "The ProgressSet was mutated in a `insert_voter` that returned error."
+            "The ProgressTracker was mutated in a `insert_voter` that returned error."
         );
         Ok(())
     }
 
     #[test]
     fn test_insert_redundant_learner() -> Result<()> {
-        let mut set = ProgressSet::new(default_logger());
+        let mut set = ProgressTracker::new(256, default_logger());
         let default_progress = Progress::new(0, 256);
         let mut canary_progress = Progress::new(0, 256);
         canary_progress.matched = CANARY;
@@ -449,14 +524,14 @@ mod test_progress_set {
         assert_eq!(
             *set.get(1).expect("Should be inserted."),
             default_progress,
-            "The ProgressSet was mutated in a `insert_learner` that returned error."
+            "The ProgressTracker was mutated in a `insert_learner` that returned error."
         );
         Ok(())
     }
 
     #[test]
     fn test_insert_learner_that_is_voter() -> Result<()> {
-        let mut set = ProgressSet::new(default_logger());
+        let mut set = ProgressTracker::new(256, default_logger());
         let default_progress = Progress::new(0, 256);
         let mut canary_progress = Progress::new(0, 256);
         canary_progress.matched = CANARY;
@@ -468,14 +543,14 @@ mod test_progress_set {
         assert_eq!(
             *set.get(1).expect("Should be inserted."),
             default_progress,
-            "The ProgressSet was mutated in a `insert_learner` that returned error."
+            "The ProgressTracker was mutated in a `insert_learner` that returned error."
         );
         Ok(())
     }
 
     #[test]
     fn test_insert_voter_that_is_learner() -> Result<()> {
-        let mut set = ProgressSet::new(default_logger());
+        let mut set = ProgressTracker::new(256, default_logger());
         let default_progress = Progress::new(0, 256);
         let mut canary_progress = Progress::new(0, 256);
         canary_progress.matched = CANARY;
@@ -487,14 +562,14 @@ mod test_progress_set {
         assert_eq!(
             *set.get(1).expect("Should be inserted."),
             default_progress,
-            "The ProgressSet was mutated in a `insert_voter` that returned error."
+            "The ProgressTracker was mutated in a `insert_voter` that returned error."
         );
         Ok(())
     }
 
     #[test]
     fn test_promote_learner() -> Result<()> {
-        let mut set = ProgressSet::new(default_logger());
+        let mut set = ProgressTracker::new(256, default_logger());
         let default_progress = Progress::new(0, 256);
         set.insert_voter(1, default_progress)?;
         let pre = set.get(1).expect("Should have been inserted").clone();


### PR DESCRIPTION
This PR ports joint quorum. It rename ProgressSet to ProgressTracker
and keep both name and field layout just like etcd.

In addition, the PR fixes a performance issue discovered earlier that
campaign prints too much logs.

joint.rs is ported from etcd/raft/quorum/joint.go and tracker is from
etcd/raft/tracker/tracker.go.