### PR TITLE
*: introduce confchange package

### DIFF
--- a/proto/proto/eraftpb.proto
+++ b/proto/proto/eraftpb.proto
@@ -138,7 +138,7 @@ message ConfChange {
 // ConfChangeSingle is an individual configuration change operation. Multiple
 // such operations can be carried out atomically via a ConfChangeV2.
 message ConfChangeSingle {
-    ConfChangeType type = 1;
+    ConfChangeType cc_type = 1;
     uint64 node_id = 2;
 }
 

--- a/src/confchange.rs
+++ b/src/confchange.rs
@@ -1,0 +1,7 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+mod changer;
+mod restore;
+
+pub use self::changer::{Changer, MapChange, MapChangeType};
+pub use self::restore::restore;

--- a/src/confchange/changer.rs
+++ b/src/confchange/changer.rs
@@ -173,7 +173,7 @@ impl Changer<'_> {
                 // here to ignore these.
                 continue;
             }
-            match cc.get_field_type() {
+            match cc.get_cc_type() {
                 ConfChangeType::AddNode => self.make_voter(cfg, prs, cc.node_id),
                 ConfChangeType::AddLearnerNode => self.make_learner(cfg, prs, cc.node_id),
                 ConfChangeType::RemoveNode => self.remove(cfg, prs, cc.node_id),

--- a/src/confchange/changer.rs
+++ b/src/confchange/changer.rs
@@ -1,0 +1,361 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use crate::eraftpb::{ConfChangeSingle, ConfChangeType};
+use crate::tracker::{Configuration, ProgressMap, ProgressTracker};
+use crate::{Error, Result};
+
+/// Change log for progress map.
+pub enum MapChangeType {
+    Add,
+    Remove,
+}
+
+/// Changes made by `Changer`.
+pub type MapChange = Vec<(u64, MapChangeType)>;
+
+/// A map that stores updates instead of apply them directly.
+pub struct IncrChangeMap<'a> {
+    changes: MapChange,
+    base: &'a ProgressMap,
+}
+
+impl IncrChangeMap<'_> {
+    pub fn into_changes(self) -> MapChange {
+        self.changes
+    }
+
+    fn contains(&self, id: u64) -> bool {
+        match self.changes.iter().rfind(|(i, _)| *i == id) {
+            Some((_, MapChangeType::Remove)) => false,
+            Some((_, MapChangeType::Add)) => true,
+            None => self.base.contains_key(&id),
+        }
+    }
+}
+
+/// Changer facilitates configuration changes. It exposes methods to handle
+/// simple and joint consensus while performing the proper validation that allows
+/// refusing invalid configuration changes before they affect the active
+/// configuration.
+pub struct Changer<'a> {
+    tracker: &'a ProgressTracker,
+}
+
+impl Changer<'_> {
+    /// Creates a changer.
+    pub fn new(tracker: &ProgressTracker) -> Changer {
+        Changer { tracker }
+    }
+
+    /// Verifies that the outgoing (=right) majority config of the joint
+    /// config is empty and initializes it with a copy of the incoming (=left)
+    /// majority config. That is, it transitions from
+    /// ```text
+    ///     (1 2 3)&&()
+    /// ```
+    /// to
+    /// ```text
+    ///     (1 2 3)&&(1 2 3)
+    /// ```.
+    ///
+    /// The supplied changes are then applied to the incoming majority config,
+    /// resulting in a joint configuration that in terms of the Raft thesis[1]
+    /// (Section 4.3) corresponds to `C_{new,old}`.
+    ///
+    /// [1]: https://github.com/ongardie/dissertation/blob/master/online-trim.pdf
+    pub fn enter_joint(
+        &self,
+        auto_leave: bool,
+        ccs: &[ConfChangeSingle],
+    ) -> Result<(Configuration, MapChange)> {
+        if joint(self.tracker.conf()) {
+            return Err(Error::ConfChangeError(
+                "configuration is already joint".to_owned(),
+            ));
+        }
+        let (mut cfg, mut prs) = self.check_and_copy()?;
+        if cfg.voters().incoming.is_empty() {
+            // We allow adding nodes to an empty config for convenience (testing and
+            // bootstrap), but you can't enter a joint state.
+            return Err(Error::ConfChangeError(
+                "can't make a zero-voter config joint".to_owned(),
+            ));
+        }
+        cfg.voters
+            .outgoing
+            .extend(cfg.voters.incoming.iter().cloned());
+        self.apply(&mut cfg, &mut prs, ccs)?;
+        cfg.auto_leave = auto_leave;
+        check_invariants(&cfg, &prs)?;
+        Ok((cfg, prs.into_changes()))
+    }
+
+    /// Transitions out of a joint configuration. It is an error to call this method if
+    /// the configuration is not joint, i.e. if the outgoing majority config is empty.
+    ///
+    /// The outgoing majority config of the joint configuration will be removed, that is,
+    /// the incoming config is promoted as the sole decision maker. In the notation of
+    /// the Raft thesis[1] (Section 4.3), this method transitions from `C_{new,old}` into
+    /// `C_new`.
+    ///
+    /// At the same time, any staged learners (LearnersNext) the addition of which was
+    /// held back by an overlapping voter in the former outgoing config will be inserted
+    /// into Learners.
+    ///
+    /// [1]: https://github.com/ongardie/dissertation/blob/master/online-trim.pdf
+    pub fn leave_joint(&self) -> Result<(Configuration, MapChange)> {
+        if !joint(self.tracker.conf()) {
+            return Err(Error::ConfChangeError(
+                "can't leave a non-joint config".to_owned(),
+            ));
+        }
+        let (mut cfg, mut prs) = self.check_and_copy()?;
+        if cfg.voters().outgoing.is_empty() {
+            return Err(Error::ConfChangeError(format!(
+                "configuration is not joint: {:?}",
+                cfg
+            )));
+        }
+        cfg.learners.extend(cfg.learners_next.drain());
+
+        for id in &*cfg.voters.outgoing {
+            if !cfg.voters.incoming.contains(id) && !cfg.learners.contains(id) {
+                prs.changes.push((*id, MapChangeType::Remove));
+            }
+        }
+
+        cfg.voters.outgoing.clear();
+        cfg.auto_leave = false;
+        check_invariants(&cfg, &prs)?;
+        Ok((cfg, prs.into_changes()))
+    }
+
+    /// Carries out a series of configuration changes that (in aggregate) mutates the
+    /// incoming majority config Voters[0] by at most one. This method will return an
+    /// error if that is not the case, if the resulting quorum is zero, or if the
+    /// configuration is in a joint state (i.e. if there is an outgoing configuration).
+    pub fn simple(&mut self, ccs: &[ConfChangeSingle]) -> Result<(Configuration, MapChange)> {
+        if joint(self.tracker.conf()) {
+            return Err(Error::ConfChangeError(
+                "can't apply simple config change in joint config".to_owned(),
+            ));
+        }
+        let (mut cfg, mut prs) = self.check_and_copy()?;
+        self.apply(&mut cfg, &mut prs, ccs)?;
+        if cfg
+            .voters
+            .incoming
+            .symmetric_difference(&self.tracker.conf().voters.incoming)
+            .count()
+            > 1
+        {
+            return Err(Error::ConfChangeError(
+                "more than one voter changed without entering joint config".to_owned(),
+            ));
+        }
+        check_invariants(&cfg, &prs)?;
+        Ok((cfg, prs.into_changes()))
+    }
+
+    /// Applies a change to the configuration. By convention, changes to voters are always
+    /// made to the incoming majority config. Outgoing is either empty or preserves the
+    /// outgoing majority configuration while in a joint state.
+    fn apply(
+        &self,
+        cfg: &mut Configuration,
+        prs: &mut IncrChangeMap,
+        ccs: &[ConfChangeSingle],
+    ) -> Result<()> {
+        for cc in ccs {
+            if cc.node_id == 0 {
+                // Replaces the NodeID with zero if it decides (downstream of
+                // raft) to not apply a change, so we have to have explicit code
+                // here to ignore these.
+                continue;
+            }
+            match cc.get_field_type() {
+                ConfChangeType::AddNode => self.make_voter(cfg, prs, cc.node_id),
+                ConfChangeType::AddLearnerNode => self.make_learner(cfg, prs, cc.node_id),
+                ConfChangeType::RemoveNode => self.remove(cfg, prs, cc.node_id),
+            }
+        }
+        if cfg.voters().incoming.is_empty() {
+            return Err(Error::ConfChangeError("removed all voters".to_owned()));
+        }
+        Ok(())
+    }
+
+    /// Adds or promotes the given ID to be a voter in the incoming majority config.
+    fn make_voter(&self, cfg: &mut Configuration, prs: &mut IncrChangeMap, id: u64) {
+        if !prs.contains(id) {
+            self.init_progress(cfg, prs, id, false);
+            return;
+        }
+
+        cfg.voters.incoming.insert(id);
+        cfg.learners.remove(&id);
+        cfg.learners_next.remove(&id);
+    }
+
+    /// Makes the given ID a learner or stages it to be a learner once an active joint
+    /// configuration is exited.
+    ///
+    /// The former happens when the peer is not a part of the outgoing config, in which
+    /// case we either add a new learner or demote a voter in the incoming config.
+    ///
+    /// The latter case occurs when the configuration is joint and the peer is a voter
+    /// in the outgoing config. In that case, we do not want to add the peer as a learner
+    /// because then we'd have to track a peer as a voter and learner simultaneously.
+    /// Instead, we add the learner to LearnersNext, so that it will be added to Learners
+    /// the moment the outgoing config is removed by LeaveJoint().
+    fn make_learner(&self, cfg: &mut Configuration, prs: &mut IncrChangeMap, id: u64) {
+        if !prs.contains(id) {
+            self.init_progress(cfg, prs, id, true);
+            return;
+        }
+
+        if cfg.learners.contains(&id) {
+            return;
+        }
+
+        cfg.voters.incoming.remove(&id);
+        cfg.learners.remove(&id);
+        cfg.learners_next.remove(&id);
+
+        // Use LearnersNext if we can't add the learner to Learners directly, i.e.
+        // if the peer is still tracked as a voter in the outgoing config. It will
+        // be turned into a learner in LeaveJoint().
+        //
+        // Otherwise, add a regular learner right away.
+        if cfg.voters().outgoing.contains(&id) {
+            cfg.learners_next.insert(id);
+        } else {
+            cfg.learners.insert(id);
+        }
+    }
+
+    /// Removes this peer as a voter or learner from the incoming config.
+    fn remove(&self, cfg: &mut Configuration, prs: &mut IncrChangeMap, id: u64) {
+        if !prs.contains(id) {
+            return;
+        }
+
+        cfg.voters.incoming.remove(&id);
+        cfg.learners.remove(&id);
+        cfg.learners_next.remove(&id);
+
+        // If the peer is still a voter in the outgoing config, keep the Progress.
+        if !cfg.voters.outgoing.contains(&id) {
+            prs.changes.push((id, MapChangeType::Remove));
+        }
+    }
+
+    /// Initializes a new progress for the given node or learner.
+    fn init_progress(
+        &self,
+        cfg: &mut Configuration,
+        prs: &mut IncrChangeMap,
+        id: u64,
+        is_learner: bool,
+    ) {
+        if !is_learner {
+            cfg.voters.incoming.insert(id);
+        } else {
+            cfg.learners.insert(id);
+        }
+        prs.changes.push((id, MapChangeType::Add));
+    }
+
+    /// Copies the tracker's config. It returns an error if checkInvariants does.
+    ///
+    /// Unlike Etcd, we don't copy progress as we don't need to mutate the `is_learner`
+    /// flags. Additions and Removals should be done after everything is checked OK.
+    fn check_and_copy(&self) -> Result<(Configuration, IncrChangeMap)> {
+        let prs = IncrChangeMap {
+            changes: vec![],
+            base: self.tracker.progress(),
+        };
+        check_invariants(self.tracker.conf(), &prs)?;
+        Ok((self.tracker.conf().clone(), prs))
+    }
+}
+
+/// Makes sure that the config and progress are compatible with each other.
+/// This is used to check both what the Changer is initialized with, as well
+/// as what it returns.
+fn check_invariants(cfg: &Configuration, prs: &IncrChangeMap) -> Result<()> {
+    // NB: intentionally allow the empty config. In production we'll never see a
+    // non-empty config (we prevent it from being created) but we will need to
+    // be able to *create* an initial config, for example during bootstrap (or
+    // during tests). Instead of having to hand-code this, we allow
+    // transitioning from an empty config into any other legal and non-empty
+    // config.
+    for id in cfg.voters().ids().iter() {
+        if !prs.contains(id) {
+            return Err(Error::ConfChangeError(format!(
+                "no progress for voter {}",
+                id
+            )));
+        }
+    }
+    for id in &cfg.learners {
+        if !prs.contains(*id) {
+            return Err(Error::ConfChangeError(format!(
+                "no progress for learner {}",
+                id
+            )));
+        }
+        // Conversely Learners and Voters doesn't intersect at all.
+        if cfg.voters().outgoing.contains(id) {
+            return Err(Error::ConfChangeError(format!(
+                "{} is in learners and outgoing voters",
+                id
+            )));
+        }
+        if cfg.voters().incoming.contains(id) {
+            return Err(Error::ConfChangeError(format!(
+                "{} is in learners and incoming voters",
+                id
+            )));
+        }
+    }
+    for id in &cfg.learners_next {
+        if !prs.contains(*id) {
+            return Err(Error::ConfChangeError(format!(
+                "no progress for learner(next) {}",
+                id
+            )));
+        }
+
+        // Any staged learner was staged because it could not be directly added due
+        // to a conflicting voter in the outgoing config.
+        if !cfg.voters().outgoing.contains(id) {
+            return Err(Error::ConfChangeError(format!(
+                "{} is in learners_next and outgoing voters",
+                id
+            )));
+        }
+    }
+
+    if !joint(cfg) {
+        // Etcd enforces outgoing and learner_next to be nil map. But there is no nil
+        // in rust. We just check empty for simplicity.
+        if !cfg.learners_next().is_empty() {
+            return Err(Error::ConfChangeError(
+                "learners_next must be empty when not joint".to_owned(),
+            ));
+        }
+        if cfg.auto_leave {
+            return Err(Error::ConfChangeError(
+                "auto_leave must be false when not joint".to_owned(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+#[inline]
+fn joint(cfg: &Configuration) -> bool {
+    !cfg.voters().outgoing.is_empty()
+}

--- a/src/confchange/restore.rs
+++ b/src/confchange/restore.rs
@@ -1,0 +1,104 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+// TODO: remove following line
+#![allow(dead_code)]
+
+use super::changer::Changer;
+use crate::eraftpb::{ConfChangeSingle, ConfChangeType, ConfState};
+use crate::tracker::ProgressTracker;
+use crate::{util, Result};
+
+/// Translates a conf state into 1) a slice of operations creating first the config that
+/// will become the outgoing one, and then the incoming one, and b) another slice that,
+/// when applied to the config resulted from 1), represents the ConfState.
+fn to_conf_change_single(cs: &ConfState) -> (Vec<ConfChangeSingle>, Vec<ConfChangeSingle>) {
+    // Example to follow along this code:
+    // voters=(1 2 3) learners=(5) outgoing=(1 2 4 6) learners_next=(4)
+    //
+    // This means that before entering the joint config, the configuration
+    // had voters (1 2 4 6) and perhaps some learners that are already gone.
+    // The new set of voters is (1 2 3), i.e. (1 2) were kept around, and (4 6)
+    // are no longer voters; however 4 is poised to become a learner upon leaving
+    // the joint state.
+    // We can't tell whether 5 was a learner before entering the joint config,
+    // but it doesn't matter (we'll pretend that it wasn't).
+    //
+    // The code below will construct
+    // outgoing = add 1; add 2; add 4; add 6
+    // incoming = remove 1; remove 2; remove 4; remove 6
+    //            add 1;    add 2;    add 3;
+    //            add-learner 5;
+    //            add-learner 4;
+    //
+    // So, when starting with an empty config, after applying 'outgoing' we have
+    //
+    //   quorum=(1 2 4 6)
+    //
+    // From which we enter a joint state via 'incoming'
+    //
+    //   quorum=(1 2 3)&&(1 2 4 6) learners=(5) learners_next=(4)
+    //
+    // as desired.
+    let mut incoming = Vec::new();
+    let mut outgoing = Vec::new();
+    for id in cs.get_voters_outgoing() {
+        // If there are outgoing voters, first add them one by one so that the
+        // (non-joint) config has them all.
+        outgoing.push(util::new_conf_change_single(*id, ConfChangeType::AddNode));
+    }
+
+    // We're done constructing the outgoing slice, now on to the incoming one
+    // (which will apply on top of the config created by the outgoing slice).
+
+    // First, we'll remove all of the outgoing voters.
+    for id in cs.get_voters_outgoing() {
+        incoming.push(util::new_conf_change_single(
+            *id,
+            ConfChangeType::RemoveNode,
+        ));
+    }
+    // Then we'll add the incoming voters and learners.
+    for id in cs.get_voters() {
+        incoming.push(util::new_conf_change_single(*id, ConfChangeType::AddNode));
+    }
+    for id in cs.get_learners() {
+        incoming.push(util::new_conf_change_single(
+            *id,
+            ConfChangeType::AddLearnerNode,
+        ));
+    }
+    // Same for LearnersNext; these are nodes we want to be learners but which
+    // are currently voters in the outgoing config.
+    for id in cs.get_learners_next() {
+        incoming.push(util::new_conf_change_single(
+            *id,
+            ConfChangeType::AddLearnerNode,
+        ));
+    }
+    (outgoing, incoming)
+}
+
+/// Restore takes a Changer (which must represent an empty configuration), and runs a
+/// sequence of changes enacting the configuration described in the ConfState.
+///
+/// TODO(tbg) it's silly that this takes a Changer. Unravel this by making sure the
+/// Changer only needs a ProgressMap (not a whole Tracker) at which point this can just
+/// take LastIndex and MaxInflight directly instead and cook up the results from that
+/// alone.
+pub fn restore(tracker: &mut ProgressTracker, next_idx: u64, cs: ConfState) -> Result<()> {
+    let (outgoing, incoming) = to_conf_change_single(&cs);
+    if outgoing.is_empty() {
+        for i in incoming {
+            let (cfg, changes) = Changer::new(tracker).simple(&[i])?;
+            tracker.apply_conf(cfg, changes, next_idx);
+        }
+    } else {
+        for cc in outgoing {
+            let (cfg, changes) = Changer::new(tracker).simple(&[cc])?;
+            tracker.apply_conf(cfg, changes, next_idx);
+        }
+        let (cfg, changes) = Changer::new(tracker).enter_joint(cs.auto_leave, &incoming)?;
+        tracker.apply_conf(cfg, changes, next_idx);
+    }
+    Ok(())
+}

--- a/src/confchange/restore.rs
+++ b/src/confchange/restore.rs
@@ -81,10 +81,7 @@ fn to_conf_change_single(cs: &ConfState) -> (Vec<ConfChangeSingle>, Vec<ConfChan
 /// Restore takes a Changer (which must represent an empty configuration), and runs a
 /// sequence of changes enacting the configuration described in the ConfState.
 ///
-/// TODO(tbg) it's silly that this takes a Changer. Unravel this by making sure the
-/// Changer only needs a ProgressMap (not a whole Tracker) at which point this can just
-/// take LastIndex and MaxInflight directly instead and cook up the results from that
-/// alone.
+/// TODO(jay) find a way to only take `ProgressMap` instead of a whole tracker.
 pub fn restore(tracker: &mut ProgressTracker, next_idx: u64, cs: ConfState) -> Result<()> {
     let (outgoing, incoming) = to_conf_change_single(&cs);
     if outgoing.is_empty() {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,6 +50,10 @@ quick_error! {
         NotExists(id: u64, set: &'static str) {
             display("The node {} is not in the {} set.", id, set)
         }
+        /// ConfChange proposal is invalid.
+        ConfChangeError(message: String) {
+            display("{}", message)
+        }
         /// The request snapshot is dropped.
         RequestSnapshotDropped {
             description("raft: request snapshot dropped")
@@ -61,13 +65,14 @@ impl PartialEq for Error {
     #[cfg_attr(feature = "cargo-clippy", allow(clippy::match_same_arms))]
     fn eq(&self, other: &Error) -> bool {
         match (self, other) {
-            (&Error::StepPeerNotFound, &Error::StepPeerNotFound) => true,
-            (&Error::ProposalDropped, &Error::ProposalDropped) => true,
-            (&Error::Store(ref e1), &Error::Store(ref e2)) => e1 == e2,
-            (&Error::Io(ref e1), &Error::Io(ref e2)) => e1.kind() == e2.kind(),
-            (&Error::StepLocalMsg, &Error::StepLocalMsg) => true,
-            (&Error::ConfigInvalid(ref e1), &Error::ConfigInvalid(ref e2)) => e1 == e2,
-            (&Error::RequestSnapshotDropped, &Error::RequestSnapshotDropped) => true,
+            (Error::StepPeerNotFound, Error::StepPeerNotFound) => true,
+            (Error::ProposalDropped, Error::ProposalDropped) => true,
+            (Error::Store(ref e1), Error::Store(ref e2)) => e1 == e2,
+            (Error::Io(ref e1), Error::Io(ref e2)) => e1.kind() == e2.kind(),
+            (Error::StepLocalMsg, Error::StepLocalMsg) => true,
+            (Error::ConfigInvalid(ref e1), Error::ConfigInvalid(ref e2)) => e1 == e2,
+            (Error::RequestSnapshotDropped, Error::RequestSnapshotDropped) => true,
+            (Error::ConfChangeError(e1), Error::ConfChangeError(e2)) => e1 == e2,
             _ => false,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,6 +470,7 @@ macro_rules! fatal {
     }};
 }
 
+mod confchange;
 mod config;
 mod errors;
 mod log_unstable;
@@ -486,6 +487,7 @@ pub mod storage;
 mod tracker;
 pub mod util;
 
+pub use self::confchange::{Changer, MapChange};
 pub use self::config::Config;
 pub use self::errors::{Error, Result, StorageError};
 pub use self::log_unstable::Unstable;

--- a/src/quorum/joint.rs
+++ b/src/quorum/joint.rs
@@ -67,17 +67,17 @@ impl Configuration {
     /// Returns true if (and only if) there is only one voting member
     /// (i.e. the leader) in the current configuration.
     pub fn is_singleton(&self) -> bool {
-        self.outgoing.voters.is_empty() && self.incoming.voters.len() == 1
+        self.outgoing.is_empty() && self.incoming.len() == 1
     }
 
     /// Returns an iterator over two hash set without cloning.
     pub fn ids(&self) -> Union<'_> {
-        Union::new(&self.incoming.voters, &self.outgoing.voters)
+        Union::new(&self.incoming, &self.outgoing)
     }
 
     /// Check if an id is a voter.
     #[inline]
     pub fn contains(&self, id: u64) -> bool {
-        self.incoming.voters.contains(&id) || self.outgoing.voters.contains(&id)
+        self.incoming.contains(&id) || self.outgoing.contains(&id)
     }
 }

--- a/src/quorum/majority.rs
+++ b/src/quorum/majority.rs
@@ -3,12 +3,13 @@
 use super::{AckedIndexer, Index, VoteResult};
 use crate::{DefaultHashBuilder, HashSet};
 use std::mem::MaybeUninit;
+use std::ops::{Deref, DerefMut};
 use std::{cmp, slice, u64};
 
 /// A set of IDs that uses majority quorums to make decisions.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Configuration {
-    pub(crate) voters: HashSet<u64>,
+    voters: HashSet<u64>,
 }
 
 impl Configuration {
@@ -129,9 +130,20 @@ impl Configuration {
             VoteResult::Lost
         }
     }
+}
 
-    /// Clears all IDs.
-    pub fn clear(&mut self) {
-        self.voters.clear();
+impl Deref for Configuration {
+    type Target = HashSet<u64>;
+
+    #[inline]
+    fn deref(&self) -> &HashSet<u64> {
+        &self.voters
+    }
+}
+
+impl DerefMut for Configuration {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut HashSet<u64> {
+        &mut self.voters
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use std::fmt::Write;
 use std::u64;
 
-use crate::eraftpb::{Entry, Message};
+use crate::eraftpb::{ConfChangeSingle, ConfChangeType, Entry, Message};
 use crate::HashSet;
 use protobuf::Message as PbMessage;
 
@@ -152,4 +152,12 @@ impl<'a> Union<'a> {
         // Usually, second is empty.
         self.first.len() + self.second.len() - self.second.intersection(&self.first).count()
     }
+}
+
+/// Creates a `ConfChangeSingle`.
+pub fn new_conf_change_single(node_id: u64, ty: ConfChangeType) -> ConfChangeSingle {
+    let mut single = ConfChangeSingle::default();
+    single.node_id = node_id;
+    single.set_field_type(ty);
+    single
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -158,6 +158,6 @@ impl<'a> Union<'a> {
 pub fn new_conf_change_single(node_id: u64, ty: ConfChangeType) -> ConfChangeSingle {
     let mut single = ConfChangeSingle::default();
     single.node_id = node_id;
-    single.set_field_type(ty);
+    single.set_cc_type(ty);
     single
 }


### PR DESCRIPTION
The package is ported from etcd/raft/confchange. restore function is not
used yet. tests will be ported after all functional codes are ported.

There is a difference between raft-rs and etcd that etcd shallow clones
progress set in changer, but raft-rs only use reference and record
changes. It's not easy to shallow clone in rust without lifetime hack
or introducing redundant containers.