### PR TITLE
Support asynchronous ready

### DIFF
--- a/benches/suites/raw_node.rs
+++ b/benches/suites/raw_node.rs
@@ -103,7 +103,7 @@ fn test_ready_raft_node(logger: &slog::Logger) -> RawNode<MemStorage> {
     let mut node = quick_raw_node(logger);
     node.raft.become_candidate();
     node.raft.become_leader();
-    let unstable = node.raft.raft_log.stable_entries();
+    let unstable = node.raft.raft_log.unstable_entries();
     node.raft.raft_log.store.wl().append(&unstable).expect("");
     node.raft.on_persist_entries(1, 1);
     node.raft.commit_apply(1);
@@ -117,8 +117,9 @@ fn test_ready_raft_node(logger: &slog::Logger) -> RawNode<MemStorage> {
         entries.push(e);
     }
     let _ = node.raft.append_entry(&mut entries);
-    let unstable = node.raft.raft_log.stable_entries();
-    node.raft.raft_log.store.wl().append(&unstable).expect("");
+    let unstable = node.raft.raft_log.unstable_entries();
+    node.raft.raft_log.store.wl().append(unstable).expect("");
+    node.raft.raft_log.stable_entries();
     // This increases 'committed_index' to `last_index` because there is only one node in quorum.
     node.raft
         .on_persist_entries(node.raft.raft_log.last_index(), 1);

--- a/benches/suites/raw_node.rs
+++ b/benches/suites/raw_node.rs
@@ -120,7 +120,7 @@ fn test_ready_raft_node(logger: &slog::Logger) -> RawNode<MemStorage> {
     let _ = node.raft.append_entry(&mut entries);
     let unstable = node.raft.raft_log.unstable_entries().to_vec();
     node.raft.raft_log.stable_entries();
-    node.raft.raft_log.store.wl().append(unstable).expect("");
+    node.raft.raft_log.store.wl().append(&unstable).expect("");
     node.raft.raft_log.stable_entries();
     // This increases 'committed_index' to `last_index` because there is only one node in quorum.
     node.raft

--- a/benches/suites/raw_node.rs
+++ b/benches/suites/raw_node.rs
@@ -103,7 +103,8 @@ fn test_ready_raft_node(logger: &slog::Logger) -> RawNode<MemStorage> {
     let mut node = quick_raw_node(logger);
     node.raft.become_candidate();
     node.raft.become_leader();
-    let unstable = node.raft.raft_log.unstable_entries();
+    let unstable = node.raft.raft_log.unstable_entries().to_vec();
+    node.raft.raft_log.stable_entries();
     node.raft.raft_log.store.wl().append(&unstable).expect("");
     node.raft.on_persist_entries(1, 1);
     node.raft.commit_apply(1);
@@ -117,7 +118,8 @@ fn test_ready_raft_node(logger: &slog::Logger) -> RawNode<MemStorage> {
         entries.push(e);
     }
     let _ = node.raft.append_entry(&mut entries);
-    let unstable = node.raft.raft_log.unstable_entries();
+    let unstable = node.raft.raft_log.unstable_entries().to_vec();
+    node.raft.raft_log.stable_entries();
     node.raft.raft_log.store.wl().append(unstable).expect("");
     node.raft.raft_log.stable_entries();
     // This increases 'committed_index' to `last_index` because there is only one node in quorum.

--- a/examples/five_mem_node/main.rs
+++ b/examples/five_mem_node/main.rs
@@ -325,7 +325,7 @@ fn on_ready(
 
     // Call `RawNode::advance` interface to update position flags in the raft.
     let mut res = raft_group.advance(ready);
-    // Send out the messages
+    // Send out the messages.
     handle_messages(res.take_messages());
     // Apply all committed entries.
     handle_committed_entries(raft_group, res.take_committed_entries());

--- a/examples/five_mem_node/main.rs
+++ b/examples/five_mem_node/main.rs
@@ -324,11 +324,11 @@ fn on_ready(
     }
 
     // Call `RawNode::advance` interface to update position flags in the raft.
-    let mut res = raft_group.advance(ready);
+    let mut light_rd = raft_group.advance(ready);
     // Send out the messages.
-    handle_messages(res.take_messages());
+    handle_messages(light_rd.take_messages());
     // Apply all committed entries.
-    handle_committed_entries(raft_group, res.take_committed_entries());
+    handle_committed_entries(raft_group, light_rd.take_committed_entries());
     // Advance the apply index.
     raft_group.advance_apply();
 }

--- a/examples/five_mem_node/main.rs
+++ b/examples/five_mem_node/main.rs
@@ -329,6 +329,8 @@ fn on_ready(
     handle_messages(res.take_messages());
     // Apply all committed entries.
     handle_committed_entries(raft_group, res.take_committed_entries());
+    // Advance the apply index.
+    raft_group.advance_apply();
 }
 
 fn example_config() -> Config {

--- a/examples/five_mem_node/main.rs
+++ b/examples/five_mem_node/main.rs
@@ -246,9 +246,31 @@ fn on_ready(
     // Get the `Ready` with `RawNode::ready` interface.
     let mut ready = raft_group.ready();
 
+    let handle_messages = |msgs: Vec<Vec<Message>>| {
+        for vec_msg in msgs {
+            for msg in vec_msg {
+                let to = msg.to;
+                if mailboxes[&to].send(msg).is_err() {
+                    error!(
+                        logger,
+                        "send raft message to {} fail, let Raft retry it", to
+                    );
+                }
+            }
+        }
+    };
+
+    // Send out the messages come from the node.
+    handle_messages(ready.take_messages());
+
+    if let Some(hs) = ready.hs() {
+        // Raft HardState changed, and we need to persist it.
+        store.wl().set_hardstate(hs.clone());
+    }
+
     // Persistent raft logs. It's necessary because in `RawNode::advance` we stabilize
     // raft logs to the latest position.
-    if let Err(e) = store.wl().append(&ready.entries) {
+    if let Err(e) = store.wl().append(ready.entries()) {
         error!(
             logger,
             "persist raft log fail: {:?}, need to retry or panic", e
@@ -268,56 +290,45 @@ fn on_ready(
         }
     }
 
-    // Send out the messages come from the node.
-    for vec_msg in ready.messages.drain(..) {
-        for msg in vec_msg {
-            let to = msg.to;
-            if mailboxes[&to].send(msg).is_err() {
-                error!(
-                    logger,
-                    "send raft message to {} fail, let Raft retry it", to
-                );
-            }
-        }
-    }
-
-    // Apply all committed proposals.
-    if let Some(committed_entries) = ready.committed_entries.take() {
-        for entry in &committed_entries {
-            if entry.data.is_empty() {
-                // From new elected leaders.
-                continue;
-            }
-            if let EntryType::EntryConfChange = entry.get_entry_type() {
-                // For conf change messages, make them effective.
-                let mut cc = ConfChange::default();
-                cc.merge_from_bytes(&entry.data).unwrap();
-                let cs = raft_group.apply_conf_change(&cc).unwrap();
-                store.wl().set_conf_state(cs);
-            } else {
-                // For normal proposals, extract the key-value pair and then
-                // insert them into the kv engine.
-                let data = str::from_utf8(&entry.data).unwrap();
-                let reg = Regex::new("put ([0-9]+) (.+)").unwrap();
-                if let Some(caps) = reg.captures(&data) {
-                    kv_pairs.insert(caps[1].parse().unwrap(), caps[2].to_string());
+    let mut handle_committed_entries =
+        |rn: &mut RawNode<MemStorage>, committed_entries: Vec<Entry>| {
+            for entry in committed_entries {
+                if entry.data.is_empty() {
+                    // From new elected leaders.
+                    continue;
+                }
+                if let EntryType::EntryConfChange = entry.get_entry_type() {
+                    // For conf change messages, make them effective.
+                    let mut cc = ConfChange::default();
+                    cc.merge_from_bytes(&entry.data).unwrap();
+                    let cs = rn.apply_conf_change(&cc).unwrap();
+                    store.wl().set_conf_state(cs);
+                } else {
+                    // For normal proposals, extract the key-value pair and then
+                    // insert them into the kv engine.
+                    let data = str::from_utf8(&entry.data).unwrap();
+                    let reg = Regex::new("put ([0-9]+) (.+)").unwrap();
+                    if let Some(caps) = reg.captures(&data) {
+                        kv_pairs.insert(caps[1].parse().unwrap(), caps[2].to_string());
+                    }
+                }
+                if rn.raft.state == StateRole::Leader {
+                    // The leader should response to the clients, tell them if their proposals
+                    // succeeded or not.
+                    let proposal = proposals.lock().unwrap().pop_front().unwrap();
+                    proposal.propose_success.send(true).unwrap();
                 }
             }
-            if raft_group.raft.state == StateRole::Leader {
-                // The leader should response to the clients, tell them if their proposals
-                // succeeded or not.
-                let proposal = proposals.lock().unwrap().pop_front().unwrap();
-                proposal.propose_success.send(true).unwrap();
-            }
-        }
-        if let Some(last_committed) = committed_entries.last() {
-            let mut s = store.wl();
-            s.mut_hard_state().commit = last_committed.index;
-            s.mut_hard_state().term = last_committed.term;
-        }
-    }
+        };
+    // Apply all committed entries.
+    handle_committed_entries(raft_group, ready.take_committed_entries());
+
     // Call `RawNode::advance` interface to update position flags in the raft.
-    raft_group.advance(ready);
+    let mut res = raft_group.advance(ready);
+    // Send out the messages
+    handle_messages(res.take_messages());
+    // Apply all committed entries.
+    handle_committed_entries(raft_group, res.take_committed_entries());
 }
 
 fn example_config() -> Config {

--- a/examples/five_mem_node/main.rs
+++ b/examples/five_mem_node/main.rs
@@ -271,14 +271,14 @@ fn on_ready(
     // Send out the messages come from the node.
     for vec_msg in ready.messages.drain(..) {
         for msg in vec_msg {
-        let to = msg.to;
-        if mailboxes[&to].send(msg).is_err() {
-            error!(
-                logger,
-                "send raft message to {} fail, let Raft retry it", to
-            );
+            let to = msg.to;
+            if mailboxes[&to].send(msg).is_err() {
+                error!(
+                    logger,
+                    "send raft message to {} fail, let Raft retry it", to
+                );
+            }
         }
-    }
     }
 
     // Apply all committed proposals.

--- a/examples/single_mem_node/main.rs
+++ b/examples/single_mem_node/main.rs
@@ -166,6 +166,8 @@ fn on_ready(raft_group: &mut RawNode<MemStorage>, cbs: &mut HashMap<u8, ProposeC
     handle_messages(res.take_messages());
     // Apply all committed entries.
     handle_committed_entries(res.take_committed_entries());
+    // Advance the apply index.
+    raft_group.advance_apply();
 }
 
 fn send_propose(logger: Logger, sender: mpsc::Sender<Msg>) {

--- a/examples/single_mem_node/main.rs
+++ b/examples/single_mem_node/main.rs
@@ -102,52 +102,43 @@ fn main() {
     }
 }
 
-fn on_ready(r: &mut RawNode<MemStorage>, cbs: &mut HashMap<u8, ProposeCallback>) {
-    if !r.has_ready() {
+fn on_ready(raft_group: &mut RawNode<MemStorage>, cbs: &mut HashMap<u8, ProposeCallback>) {
+    if !raft_group.has_ready() {
         return;
     }
+    let store = raft_group.raft.raft_log.store.clone();
 
-    // The Raft is ready, we can do something now.
-    let mut ready = r.ready();
+    // Get the `Ready` with `RawNode::ready` interface.
+    let mut ready = raft_group.ready();
 
-    let is_leader = r.raft.leader_id == r.raft.id;
-    if is_leader {
-        // If the peer is leader, the leader can send messages to other followers ASAP.
-        let msgs = ready.messages.drain(..);
-        for _msg in msgs {
-            // Here we only have one peer, so can ignore this.
+    let handle_messages = |msgs: Vec<Vec<Message>>| {
+        for vec_msg in msgs {
+            for _msg in vec_msg {
+                // Send messages to other peers.
+            }
         }
+    };
+
+    // Send out the messages come from the node.
+    handle_messages(ready.take_messages());
+
+    if let Some(hs) = ready.hs() {
+        // Raft HardState changed, and we need to persist it.
+        store.wl().set_hardstate(hs.clone());
+    }
+
+    if !ready.entries().is_empty() {
+        // Append entries to the Raft log.
+        store.wl().append(&ready.entries()).unwrap();
     }
 
     if !ready.snapshot().is_empty() {
         // This is a snapshot, we need to apply the snapshot at first.
-        r.mut_store()
-            .wl()
-            .apply_snapshot(ready.snapshot().clone())
-            .unwrap();
+        store.wl().apply_snapshot(ready.snapshot().clone()).unwrap();
     }
 
-    if !ready.entries.is_empty() {
-        // Append entries to the Raft log
-        r.mut_store().wl().append(&ready.entries).unwrap();
-    }
-
-    if let Some(hs) = ready.hs() {
-        // Raft HardState changed, and we need to persist it.
-        r.mut_store().wl().set_hardstate(hs.clone());
-    }
-
-    if !is_leader {
-        // If not leader, the follower needs to reply the messages to
-        // the leader after appending Raft entries.
-        let msgs = ready.messages.drain(..);
-        for _msg in msgs {
-            // Send messages to other peers.
-        }
-    }
-
-    if let Some(committed_entries) = ready.committed_entries.take() {
-        let mut _last_apply_index = 0;
+    let mut _last_apply_index = 0;
+    let mut handle_committed_entries = |committed_entries: Vec<Entry>| {
         for entry in committed_entries {
             // Mostly, you need to save the last apply index to resume applying
             // after restart. Here we just ignore this because we use a Memory storage.
@@ -166,10 +157,15 @@ fn on_ready(r: &mut RawNode<MemStorage>, cbs: &mut HashMap<u8, ProposeCallback>)
 
             // TODO: handle EntryConfChange
         }
-    }
+    };
+    handle_committed_entries(ready.take_committed_entries());
 
-    // Advance the Raft
-    r.advance(ready);
+    // Advance the Raft.
+    let mut res = raft_group.advance(ready);
+    // Send out the messages.
+    handle_messages(res.take_messages());
+    // Apply all committed entries.
+    handle_committed_entries(res.take_committed_entries());
 }
 
 fn send_propose(logger: Logger, sender: mpsc::Sender<Msg>) {

--- a/examples/single_mem_node/main.rs
+++ b/examples/single_mem_node/main.rs
@@ -161,11 +161,11 @@ fn on_ready(raft_group: &mut RawNode<MemStorage>, cbs: &mut HashMap<u8, ProposeC
     }
 
     // Advance the Raft.
-    let mut res = raft_group.advance(ready);
+    let mut light_rd = raft_group.advance(ready);
     // Send out the messages.
-    handle_messages(res.take_messages());
+    handle_messages(light_rd.take_messages());
     // Apply all committed entries.
-    handle_committed_entries(res.take_committed_entries());
+    handle_committed_entries(light_rd.take_committed_entries());
     // Advance the apply index.
     raft_group.advance_apply();
 }

--- a/examples/single_mem_node/main.rs
+++ b/examples/single_mem_node/main.rs
@@ -127,9 +127,9 @@ fn on_ready(r: &mut RawNode<MemStorage>, cbs: &mut HashMap<u8, ProposeCallback>)
             .unwrap();
     }
 
-    if !ready.entries().is_empty() {
+    if !ready.entries.is_empty() {
         // Append entries to the Raft log
-        r.mut_store().wl().append(ready.entries()).unwrap();
+        r.mut_store().wl().append(&ready.entries).unwrap();
     }
 
     if let Some(hs) = ready.hs() {

--- a/harness/src/interface.rs
+++ b/harness/src/interface.rs
@@ -56,14 +56,19 @@ impl Interface {
     /// Persist the unstable snapshot and entries.
     pub fn persist(&mut self) {
         if self.raft.is_some() {
-            if let Some(snapshot) = self.raft_log.stable_snap() {
-                self.commit_apply(snapshot.get_metadata().index);
-                self.mut_store().wl().apply_snapshot(snapshot).expect("");
+            if let Some(snapshot) = self.raft_log.unstable_snapshot() {
+                let snap = snapshot.clone();
+                self.raft_log.stable_snap();
+                let (index, term) = (snap.get_metadata().index, snap.get_metadata().term);
+                self.mut_store().wl().apply_snapshot(snap).expect("");
+                self.on_persist_snap(index, term);
+                self.commit_apply(index);
             }
-            let unstable = self.raft_log.stable_entries();
+            let unstable = self.raft_log.unstable_entries().to_vec();
             if !unstable.is_empty() {
-                self.mut_store().wl().append(&unstable).expect("");
+                self.raft_log.stable_entries();
                 let last_entry = unstable.last().unwrap();
+                self.mut_store().wl().append(&unstable).expect("");
                 self.on_persist_entries(last_entry.index, last_entry.term);
             }
         }

--- a/harness/src/interface.rs
+++ b/harness/src/interface.rs
@@ -59,9 +59,8 @@ impl Interface {
             if let Some(snapshot) = self.raft_log.unstable_snapshot() {
                 let snap = snapshot.clone();
                 self.raft_log.stable_snap();
-                let (index, term) = (snap.get_metadata().index, snap.get_metadata().term);
+                let index = snap.get_metadata().index;
                 self.mut_store().wl().apply_snapshot(snap).expect("");
-                self.on_persist_snap(index, term);
                 self.commit_apply(index);
             }
             let unstable = self.raft_log.unstable_entries().to_vec();

--- a/harness/src/network.rs
+++ b/harness/src/network.rs
@@ -167,6 +167,8 @@ impl Network {
                 let resp = {
                     let p = self.peers.get_mut(&m.to).unwrap();
                     let _ = p.step(m);
+                    // The unstable data should be persisted before sending msg.
+                    p.persist();
                     p.read_messages()
                 };
                 new_msgs.append(&mut self.filter(resp));

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -2700,7 +2700,7 @@ fn test_bcast_beat() {
     let last_index = sm.raft_log.last_index();
     mut_pr(&mut sm, 3, last_index, last_index + 1);
 
-    // Use Raft::step explicitly to bypass persist_entries inside to forward commit index and send append msg
+    // Use Raft::step explicitly to bypass persist_entries inside which forwards commit index and sends append msg
     Raft::step(&mut sm, new_message(0, 0, MessageType::MsgBeat, 0)).expect("");
     let mut msgs = sm.read_messages();
     assert_eq!(msgs.len(), 2);

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -2702,8 +2702,8 @@ fn test_bcast_beat() {
     let last_index = sm.raft_log.last_index();
     mut_pr(&mut sm, 3, last_index, last_index + 1);
 
-    // Use Raft::step explicitly to bypass persist_entries inside which forwards commit index and sends append msg
-    Raft::step(&mut sm, new_message(0, 0, MessageType::MsgBeat, 0)).expect("");
+    sm.step(new_message(0, 0, MessageType::MsgBeat, 0))
+        .expect("");
     let mut msgs = sm.read_messages();
     assert_eq!(msgs.len(), 2);
 

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -2700,7 +2700,7 @@ fn test_bcast_beat() {
     let last_index = sm.raft_log.last_index();
     mut_pr(&mut sm, 3, last_index, last_index + 1);
 
-    // Use Raft::step explicitly to avoid persist_entries inside to forward commit index
+    // Use Raft::step explicitly to bypass persist_entries inside to forward commit index and send append msg
     Raft::step(&mut sm, new_message(0, 0, MessageType::MsgBeat, 0)).expect("");
     let mut msgs = sm.read_messages();
     assert_eq!(msgs.len(), 2);

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -104,6 +104,7 @@ fn next_ents(r: &mut Raft<MemStorage>, s: &MemStorage) -> Vec<Entry> {
     }
     let (last_idx, last_term) = (r.raft_log.last_index(), r.raft_log.last_term());
     r.raft_log.stable_to(last_idx, last_term);
+    r.on_persist_entries(last_idx, last_term);
     let ents = r.raft_log.next_entries();
     r.commit_apply(r.raft_log.committed);
     ents.unwrap_or_else(Vec::new)
@@ -913,8 +914,8 @@ fn test_dueling_candidates() {
 
     let tests = vec![
         // role, term, committed, applied, last index.
-        (StateRole::Follower, 2, (1, 0, 1)),
-        (StateRole::Follower, 2, (1, 0, 1)),
+        (StateRole::Follower, 2, (0, 0, 1)),
+        (StateRole::Follower, 2, (0, 0, 1)),
         (StateRole::Follower, 2, (0, 0, 0)),
     ];
 

--- a/harness/tests/integration_cases/test_raft_paper.rs
+++ b/harness/tests/integration_cases/test_raft_paper.rs
@@ -34,13 +34,12 @@ pub fn commit_noop_entry(r: &mut Interface, s: &MemStorage) {
     }
     // ignore further messages to refresh followers' commit index
     r.read_messages();
-    s.wl()
-        .append(r.raft_log.unstable_entries().unwrap_or(&[]))
-        .expect("");
+    let unstable = r.raft_log.stable_entries();
+    s.wl().append(&unstable).expect("");
     let committed = r.raft_log.committed;
     r.commit_apply(committed);
     let (last_index, last_term) = (r.raft_log.last_index(), r.raft_log.last_term());
-    r.raft_log.stable_to(last_index, last_term);
+    r.on_persist_entries(last_index, last_term);
 }
 
 fn accept_and_reply(m: &Message) -> Message {

--- a/harness/tests/integration_cases/test_raft_paper.rs
+++ b/harness/tests/integration_cases/test_raft_paper.rs
@@ -471,6 +471,7 @@ fn test_leader_commit_entry() {
     let li = r.raft_log.last_index();
     r.step(new_message(1, 1, MessageType::MsgPropose, 1))
         .expect("");
+    r.persist();
 
     for m in r.read_messages() {
         r.step(accept_and_reply(&m)).expect("");
@@ -514,6 +515,7 @@ fn test_leader_acknowledge_commit() {
         let li = r.raft_log.last_index();
         r.step(new_message(1, 1, MessageType::MsgPropose, 1))
             .expect("");
+        r.persist();
 
         for m in r.read_messages() {
             if acceptors.contains_key(&m.to) && acceptors[&m.to] {
@@ -556,6 +558,7 @@ fn test_leader_commit_preceding_entries() {
 
         r.step(new_message(1, 1, MessageType::MsgPropose, 1))
             .expect("");
+        r.persist();
 
         for m in r.read_messages() {
             r.step(accept_and_reply(&m)).expect("");
@@ -614,6 +617,7 @@ fn test_follower_commit_entry() {
         m.commit = commit;
         m.entries = ents.clone().into();
         r.step(m).expect("");
+        r.persist();
 
         if r.raft_log.committed != commit {
             panic!(
@@ -1029,6 +1033,7 @@ fn test_leader_only_commits_log_from_current_term() {
         // propose a entry to current term
         r.step(new_message(1, 1, MessageType::MsgPropose, 1))
             .expect("");
+        r.persist();
 
         let mut m = new_message(2, 1, MessageType::MsgAppendResponse, 0);
         m.term = r.term;

--- a/harness/tests/integration_cases/test_raft_snap.rs
+++ b/harness/tests/integration_cases/test_raft_snap.rs
@@ -28,6 +28,7 @@ fn test_sending_snapshot_set_pending_snapshot() {
     let l = default_logger();
     let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     sm.restore(testing_snap());
+    sm.persist();
 
     sm.become_candidate();
     sm.become_leader();
@@ -51,6 +52,7 @@ fn test_pending_snapshot_pause_replication() {
     let l = default_logger();
     let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     sm.restore(testing_snap());
+    sm.persist();
 
     sm.become_candidate();
     sm.become_leader();
@@ -67,6 +69,7 @@ fn test_snapshot_failure() {
     let l = default_logger();
     let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     sm.restore(testing_snap());
+    sm.persist();
 
     sm.become_candidate();
     sm.become_leader();
@@ -88,6 +91,7 @@ fn test_snapshot_succeed() {
     let l = default_logger();
     let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     sm.restore(testing_snap());
+    sm.persist();
 
     sm.become_candidate();
     sm.become_leader();
@@ -109,6 +113,7 @@ fn test_snapshot_abort() {
     let l = default_logger();
     let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     sm.restore(testing_snap());
+    sm.persist();
 
     sm.become_candidate();
     sm.become_leader();
@@ -151,6 +156,7 @@ fn test_request_snapshot() {
     let l = default_logger();
     let mut sm = new_test_raft(1, vec![1, 2], 10, 1, new_storage(), &l);
     sm.restore(testing_snap());
+    sm.persist();
 
     // Raft can not step request snapshot if there is no leader.
     assert_eq!(

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -1112,10 +1112,12 @@ fn test_async_ready_leader() {
     );
     assert!(!rd.messages().is_empty());
     s.wl().set_hardstate(rd.hs().unwrap().clone());
+    let number = rd.number();
     raw_node.advance_append_async(rd);
 
     // Forward commit index due to persist last ready
-    let res = raw_node.on_persist_last_ready();
+    raw_node.on_persist_ready(number);
+    let res = raw_node.light_ready();
     assert_eq!(res.commit_index(), Some(first_index + 100));
     assert_eq!(
         res.committed_entries().first().unwrap().get_index(),
@@ -1179,10 +1181,12 @@ fn test_async_ready_leader() {
             assert_eq!(msg.get_commit(), first_index + 9);
         }
     }
+    let number = rd.number();
     raw_node.advance_append_async(rd);
 
     // Forward commit index due to peer 1's append response and persisted entries
-    let res = raw_node.on_persist_last_ready();
+    raw_node.on_persist_ready(number);
+    let res = raw_node.light_ready();
     assert_eq!(res.commit_index(), Some(first_index + 10));
     assert_eq!(
         res.committed_entries().first().unwrap().get_index(),
@@ -1259,9 +1263,11 @@ fn test_async_ready_follower() {
             }
         }
         assert_eq!(msg_num, 4);
+        let number = rd.number();
         raw_node.advance_append_async(rd);
 
-        let mut res = raw_node.on_persist_last_ready();
+        raw_node.on_persist_ready(number);
+        let mut res = raw_node.light_ready();
         assert_eq!(res.commit_index(), None);
         assert_eq!(
             res.committed_entries().first().unwrap().get_index(),

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -614,20 +614,23 @@ fn test_raw_node_start() {
     );
     store.wl().append(rd.entries()).expect("");
     let res = raw_node.advance(rd);
+    assert_eq!(res.commit_index(), Some(2));
     assert_eq!(*res.committed_entries(), vec![new_entry(2, 2, None)]);
+    assert!(!raw_node.has_ready());
 
     raw_node.propose(vec![], b"somedata".to_vec()).expect("");
     let rd = raw_node.ready();
     must_cmp_ready(
         &rd,
         &None,
-        &Some(hard_state(2, 2, 1)),
+        &None,
         &[new_entry(2, 3, SOME_DATA)],
         vec![],
         true,
     );
     store.wl().append(rd.entries()).expect("");
     let res = raw_node.advance(rd);
+    assert_eq!(res.commit_index(), Some(3));
     assert_eq!(*res.committed_entries(), vec![new_entry(2, 3, SOME_DATA)]);
 
     assert!(!raw_node.has_ready());

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -437,6 +437,7 @@ fn test_raw_node_joint_auto_leave() {
     rd = raw_node.ready();
     s.wl().append(rd.entries()).unwrap();
     let _ = raw_node.advance(rd);
+
     rd = raw_node.ready();
     s.wl().append(rd.entries()).unwrap();
 

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -1111,10 +1111,9 @@ fn test_async_ready_leader() {
     );
     assert!(!rd.messages().is_empty());
     s.wl().set_hardstate(rd.hs().unwrap().clone());
-    raw_node.advance_append_async(rd);
 
     // Forward commit index due to persist last ready
-    let light_rd = raw_node.on_persist_last_ready();
+    let light_rd = raw_node.advance_append(rd);
     assert_eq!(light_rd.commit_index(), Some(first_index + 100));
     assert_eq!(
         light_rd.committed_entries().first().unwrap().get_index(),
@@ -1178,10 +1177,9 @@ fn test_async_ready_leader() {
             assert_eq!(msg.get_commit(), first_index + 9);
         }
     }
-    raw_node.advance_append_async(rd);
 
     // Forward commit index due to peer 1's append response and persisted entries
-    let light_rd = raw_node.on_persist_last_ready();
+    let light_rd = raw_node.advance_append(rd);
     assert_eq!(light_rd.commit_index(), Some(first_index + 10));
     assert_eq!(
         light_rd.committed_entries().first().unwrap().get_index(),
@@ -1257,9 +1255,8 @@ fn test_async_ready_follower() {
             }
         }
         assert_eq!(msg_num, 4);
-        raw_node.advance_append_async(rd);
 
-        let mut light_rd = raw_node.on_persist_last_ready();
+        let mut light_rd = raw_node.advance_append(rd);
         assert_eq!(light_rd.commit_index(), None);
         assert_eq!(
             light_rd.committed_entries().first().unwrap().get_index(),
@@ -1310,9 +1307,8 @@ fn test_async_ready_become_leader() {
         true,
     );
     s.wl().set_hardstate(rd.hs().unwrap().clone());
-    raw_node.advance_append_async(rd);
 
-    let mut light_rd = raw_node.on_persist_last_ready();
+    let mut light_rd = raw_node.advance_append(rd);
     for vec_msg in light_rd.take_messages() {
         for msg in vec_msg {
             assert_eq!(msg.get_msg_type(), MessageType::MsgRequestVote);
@@ -1376,7 +1372,7 @@ fn test_async_ready_become_leader() {
     }
     assert_eq!(count, 4);
 
-    let light_rd = raw_node.on_persist_last_ready();
+    let light_rd = raw_node.advance_append(rd);
     assert_eq!(light_rd.commit_index(), None);
     assert!(light_rd.committed_entries().is_empty());
     assert!(light_rd.messages().is_empty());

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -1009,7 +1009,7 @@ fn test_raw_node_overwrite_entries() {
 }
 
 /// Test if async ready process is expected when a leader receives
-/// the append response or persist its entries.
+/// the append response and persist its entries.
 #[test]
 fn test_async_ready_leader() {
     let l = default_logger();
@@ -1034,7 +1034,7 @@ fn test_async_ready_leader() {
 
     let data = b"hello world!";
 
-    // Change the replicate mode of 2
+    // Set node 2 progress to replicate
     raw_node.raft.mut_prs().get_mut(2).unwrap().matched = 1;
     raw_node
         .raft
@@ -1072,7 +1072,7 @@ fn test_async_ready_leader() {
     }
     // Unpersisted Ready number in range [2, 11]
     raw_node.on_persist_ready(4);
-    // No new committed entries due to 2 peers.
+    // No new committed entries due to two nodes in this cluster
     assert!(!raw_node.has_ready());
 
     // The index of uncommitted entries in range [first_index, first_index + 100]

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -41,10 +41,10 @@ fn must_cmp_ready(
 ) {
     assert_eq!(r.ss(), ss.as_ref());
     assert_eq!(r.hs(), hs.as_ref());
-    assert_eq!(r.entries(), entries);
-    assert_eq!(r.committed_entries, Some(committed_entries));
+    assert_eq!(r.entries, entries);
+    assert_eq!(r.committed_entries, committed_entries);
     assert_eq!(r.must_sync(), must_sync);
-    assert!(r.read_states().is_empty());
+    assert!(r.read_states.is_empty());
     assert_eq!(r.snapshot(), &Snapshot::default());
     assert!(r.messages.is_empty());
 }
@@ -242,20 +242,27 @@ fn test_raw_node_propose_and_conf_change() {
         let mut cs = None;
         while cs.is_none() {
             let rd = raw_node.ready();
-            s.wl().append(rd.entries()).unwrap();
-            for e in rd.committed_entries.as_ref().unwrap() {
-                if e.get_entry_type() == EntryType::EntryConfChange {
-                    let mut cc = ConfChange::default();
-                    cc.merge_from_bytes(e.get_data()).unwrap();
-                    cs = Some(raw_node.apply_conf_change(&cc).unwrap());
-                } else if e.get_entry_type() == EntryType::EntryConfChangeV2 {
-                    let mut cc = ConfChangeV2::default();
-                    cc.merge_from_bytes(e.get_data()).unwrap();
-                    cs = Some(raw_node.apply_conf_change(&cc).unwrap());
-                }
-            }
+            s.wl().append(&rd.entries).unwrap();
+            let mut handle_committed_entries =
+                |rn: &mut RawNode<MemStorage>, committed_entries: &Vec<Entry>| {
+                    for e in committed_entries {
+                        if e.get_entry_type() == EntryType::EntryConfChange {
+                            let mut cc = ConfChange::default();
+                            cc.merge_from_bytes(e.get_data()).unwrap();
+                            cs = Some(rn.apply_conf_change(&cc).unwrap());
+                        } else if e.get_entry_type() == EntryType::EntryConfChangeV2 {
+                            let mut cc = ConfChangeV2::default();
+                            cc.merge_from_bytes(e.get_data()).unwrap();
+                            cs = Some(rn.apply_conf_change(&cc).unwrap());
+                        }
+                    }
+                };
+            handle_committed_entries(&mut raw_node, &rd.committed_entries);
             let is_leader = rd.ss().map_or(false, |ss| ss.leader_id == raw_node.raft.id);
-            raw_node.advance(rd);
+            let res = raw_node.advance(rd);
+            handle_committed_entries(&mut raw_node, &res.committed_entries);
+            raw_node.advance_apply(None);
+
             // Once we are the leader, propose a command and a ConfChange.
             if !proposed && is_leader {
                 raw_node.propose(vec![], b"somedata".to_vec()).unwrap();
@@ -309,7 +316,7 @@ fn test_raw_node_propose_and_conf_change() {
         let mut rd = raw_node.ready();
         let mut context = vec![];
         if !exp.auto_leave {
-            assert!(rd.entries().is_empty());
+            assert!(rd.entries.is_empty());
             if exp2.is_none() {
                 continue;
             }
@@ -319,17 +326,11 @@ fn test_raw_node_propose_and_conf_change() {
             raw_node.propose_conf_change(vec![], cc).unwrap();
             rd = raw_node.ready();
         }
-
         // Check that the right ConfChange comes out.
-        assert_eq!(rd.entries().len(), 1);
-        assert_eq!(
-            rd.entries()[0].get_entry_type(),
-            EntryType::EntryConfChangeV2
-        );
+        assert_eq!(rd.entries.len(), 1);
+        assert_eq!(rd.entries[0].get_entry_type(), EntryType::EntryConfChangeV2);
         let mut leave_cc = ConfChangeV2::default();
-        leave_cc
-            .merge_from_bytes(rd.entries()[0].get_data())
-            .unwrap();
+        leave_cc.merge_from_bytes(rd.entries[0].get_data()).unwrap();
         assert_eq!(context, leave_cc.get_context(), "{:?}", cc.as_v2());
         // Lie and pretend the ConfChange applied. It won't do so because now
         // we require the joint quorum and we're only running one node.
@@ -358,22 +359,28 @@ fn test_raw_node_joint_auto_leave() {
     let mut cs = None;
     while cs.is_none() {
         let rd = raw_node.ready();
-        s.wl().append(rd.entries()).unwrap();
-        for e in rd.committed_entries.as_ref().unwrap() {
-            if e.get_entry_type() == EntryType::EntryConfChangeV2 {
-                let mut cc = ConfChangeV2::default();
-                cc.merge_from_bytes(e.get_data()).unwrap();
+        s.wl().append(&rd.entries).unwrap();
+        let mut handle_committed_entries =
+            |rn: &mut RawNode<MemStorage>, committed_entries: &Vec<Entry>| {
+                for e in committed_entries {
+                    if e.get_entry_type() == EntryType::EntryConfChangeV2 {
+                        let mut cc = ConfChangeV2::default();
+                        cc.merge_from_bytes(e.get_data()).unwrap();
 
-                // Force it step down.
-                let mut msg = new_message(1, 1, MessageType::MsgHeartbeatResponse, 0);
-                msg.term = raw_node.raft.term + 1;
-                raw_node.step(msg).unwrap();
+                        // Force it step down.
+                        let mut msg = new_message(1, 1, MessageType::MsgHeartbeatResponse, 0);
+                        msg.term = rn.raft.term + 1;
+                        rn.step(msg).unwrap();
 
-                cs = Some(raw_node.apply_conf_change(&cc).unwrap());
-            }
-        }
+                        cs = Some(rn.apply_conf_change(&cc).unwrap());
+                    }
+                }
+            };
+        handle_committed_entries(&mut raw_node, &rd.committed_entries);
         let is_leader = rd.ss().map_or(false, |ss| ss.leader_id == raw_node.raft.id);
-        raw_node.advance(rd);
+        let res = raw_node.advance(rd);
+        handle_committed_entries(&mut raw_node, &res.committed_entries);
+        raw_node.advance_apply(None);
         // Once we are the leader, propose a command and a ConfChange.
         if !proposed && is_leader {
             raw_node.propose(vec![], b"somedata".to_vec()).unwrap();
@@ -399,26 +406,22 @@ fn test_raw_node_joint_auto_leave() {
 
     // Move the RawNode along. It should not leave joint because it's follower.
     let mut rd = raw_node.ready();
-    assert!(rd.entries().is_empty());
+    assert!(rd.entries.is_empty());
+    raw_node.advance(rd);
 
     // Make it leader again. It should leave joint automatically after moving apply index.
     raw_node.campaign().unwrap();
     rd = raw_node.ready();
-    s.wl().append(rd.entries()).unwrap();
+    s.wl().append(&rd.entries).unwrap();
     raw_node.advance(rd);
     rd = raw_node.ready();
-    s.wl().append(rd.entries()).unwrap();
+    s.wl().append(&rd.entries).unwrap();
 
     // Check that the right ConfChange comes out.
-    assert_eq!(rd.entries().len(), 1);
-    assert_eq!(
-        rd.entries()[0].get_entry_type(),
-        EntryType::EntryConfChangeV2
-    );
+    assert_eq!(rd.entries.len(), 1);
+    assert_eq!(rd.entries[0].get_entry_type(), EntryType::EntryConfChangeV2);
     let mut leave_cc = ConfChangeV2::default();
-    leave_cc
-        .merge_from_bytes(rd.entries()[0].get_data())
-        .unwrap();
+    leave_cc.merge_from_bytes(rd.entries[0].get_data()).unwrap();
     assert!(leave_cc.get_context().is_empty());
     // Lie and pretend the ConfChange applied. It won't do so because now
     // we require the joint quorum and we're only running one node.
@@ -436,7 +439,7 @@ fn test_raw_node_propose_add_duplicate_node() {
     raw_node.campaign().expect("");
     loop {
         let rd = raw_node.ready();
-        s.wl().append(rd.entries()).expect("");
+        s.wl().append(&rd.entries).expect("");
         if rd.ss().map_or(false, |ss| ss.leader_id == raw_node.raft.id) {
             raw_node.advance(rd);
             break;
@@ -447,15 +450,21 @@ fn test_raw_node_propose_add_duplicate_node() {
     let mut propose_conf_change_and_apply = |cc| {
         raw_node.propose_conf_change(vec![], cc).expect("");
         let rd = raw_node.ready();
-        s.wl().append(rd.entries()).expect("");
-        for e in rd.committed_entries.as_ref().unwrap() {
-            if e.get_entry_type() == EntryType::EntryConfChange {
-                let mut conf_change = ConfChange::default();
-                conf_change.merge_from_bytes(&e.data).unwrap();
-                raw_node.apply_conf_change(&conf_change).unwrap();
-            }
-        }
-        raw_node.advance(rd);
+        s.wl().append(&rd.entries).expect("");
+        let handle_committed_entries =
+            |rn: &mut RawNode<MemStorage>, committed_entries: &Vec<Entry>| {
+                for e in committed_entries {
+                    if e.get_entry_type() == EntryType::EntryConfChange {
+                        let mut conf_change = ConfChange::default();
+                        conf_change.merge_from_bytes(&e.data).unwrap();
+                        rn.apply_conf_change(&conf_change).unwrap();
+                    }
+                }
+            };
+        handle_committed_entries(&mut raw_node, &rd.committed_entries);
+        let res = raw_node.advance(rd);
+        handle_committed_entries(&mut raw_node, &res.committed_entries);
+        raw_node.advance_apply(None);
     };
 
     let cc1 = conf_change(ConfChangeType::AddNode, 1);
@@ -485,13 +494,13 @@ fn test_raw_node_propose_add_learner_node() -> Result<()> {
     let s = new_storage();
     let mut raw_node = new_raw_node(1, vec![1], 10, 1, s.clone(), &l);
     let rd = raw_node.ready();
-    s.wl().append(rd.entries()).expect("");
+    s.wl().append(&rd.entries).expect("");
     raw_node.advance(rd);
 
     raw_node.campaign().expect("");
     loop {
         let rd = raw_node.ready();
-        s.wl().append(rd.entries()).expect("");
+        s.wl().append(&rd.entries).expect("");
         if rd.ss().map_or(false, |ss| ss.leader_id == raw_node.raft.id) {
             raw_node.advance(rd);
             break;
@@ -504,15 +513,17 @@ fn test_raw_node_propose_add_learner_node() -> Result<()> {
     raw_node.propose_conf_change(vec![], cc).expect("");
 
     let rd = raw_node.ready();
-    s.wl().append(rd.entries()).expect("");
+    s.wl().append(&rd.entries).expect("");
+
+    let res = raw_node.advance(rd);
 
     assert_eq!(
-        rd.committed_entries.as_ref().unwrap().len(),
+        res.committed_entries.len(),
         1,
         "should committed the conf change entry"
     );
 
-    let e = &rd.committed_entries.as_ref().unwrap()[0];
+    let e = &res.committed_entries[0];
     assert_eq!(e.get_entry_type(), EntryType::EntryConfChange);
     let mut conf_change = ConfChange::default();
     conf_change.merge_from_bytes(&e.data).unwrap();
@@ -539,7 +550,7 @@ fn test_raw_node_read_index() {
     raw_node.campaign().expect("");
     loop {
         let rd = raw_node.ready();
-        s.wl().append(rd.entries()).expect("");
+        s.wl().append(&rd.entries).expect("");
         if rd.ss().map_or(false, |ss| ss.leader_id == raw_node.raft.id) {
             raw_node.advance(rd);
 
@@ -554,8 +565,8 @@ fn test_raw_node_read_index() {
     assert!(!raw_node.raft.read_states.is_empty());
     assert!(raw_node.has_ready());
     let rd = raw_node.ready();
-    assert_eq!(rd.read_states(), wrs.as_slice());
-    s.wl().append(&rd.entries()).expect("");
+    assert_eq!(rd.read_states, wrs.as_slice());
+    s.wl().append(&rd.entries).expect("");
     raw_node.advance(rd);
 
     // ensure raft.read_states is reset after advance
@@ -574,7 +585,7 @@ fn test_raw_node_start() {
 
     let rd = raw_node.ready();
     must_cmp_ready(&rd, &None, &None, &[], vec![], false);
-    store.wl().append(rd.entries()).unwrap();
+    store.wl().append(&rd.entries).unwrap();
     raw_node.advance(rd);
 
     raw_node.campaign().expect("");
@@ -582,26 +593,28 @@ fn test_raw_node_start() {
     must_cmp_ready(
         &rd,
         &Some(soft_state(1, StateRole::Leader)),
-        &Some(hard_state(2, 2, 1)),
+        &Some(hard_state(2, 1, 1)),
         &[new_entry(2, 2, None)],
-        vec![new_entry(2, 2, None)],
+        vec![],
         true,
     );
-    store.wl().append(rd.entries()).expect("");
-    raw_node.advance(rd);
+    store.wl().append(&rd.entries).expect("");
+    let res = raw_node.advance(rd);
+    assert_eq!(res.committed_entries, vec![new_entry(2, 2, None)]);
 
     raw_node.propose(vec![], b"somedata".to_vec()).expect("");
     let rd = raw_node.ready();
     must_cmp_ready(
         &rd,
         &None,
-        &Some(hard_state(2, 3, 1)),
+        &Some(hard_state(2, 2, 1)),
         &[new_entry(2, 3, SOME_DATA)],
-        vec![new_entry(2, 3, SOME_DATA)],
+        vec![],
         true,
     );
-    store.wl().append(rd.entries()).expect("");
-    raw_node.advance(rd);
+    store.wl().append(&rd.entries).expect("");
+    let res = raw_node.advance(rd);
+    assert_eq!(res.committed_entries, vec![new_entry(2, 3, SOME_DATA)]);
 
     assert!(!raw_node.has_ready());
 }

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -262,7 +262,7 @@ fn test_raw_node_propose_and_conf_change() {
 
             let mut res = raw_node.advance(rd);
             handle_committed_entries(&mut raw_node, res.take_committed_entries());
-            raw_node.advance_apply(None);
+            raw_node.advance_apply();
 
             // Once we are the leader, propose a command and a ConfChange.
             if !proposed && is_leader {
@@ -387,7 +387,7 @@ fn test_raw_node_joint_auto_leave() {
 
         let mut res = raw_node.advance(rd);
         handle_committed_entries(&mut raw_node, res.take_committed_entries());
-        raw_node.advance_apply(None);
+        raw_node.advance_apply();
 
         // Once we are the leader, propose a command and a ConfChange.
         if !proposed && is_leader {
@@ -478,7 +478,7 @@ fn test_raw_node_propose_add_duplicate_node() {
 
         let mut res = raw_node.advance(rd);
         handle_committed_entries(&mut raw_node, res.take_committed_entries());
-        raw_node.advance_apply(None);
+        raw_node.advance_apply();
     };
 
     let cc1 = conf_change(ConfChangeType::AddNode, 1);

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -1112,12 +1112,10 @@ fn test_async_ready_leader() {
     );
     assert!(!rd.messages().is_empty());
     s.wl().set_hardstate(rd.hs().unwrap().clone());
-    let number = rd.number();
     raw_node.advance_append_async(rd);
 
     // Forward commit index due to persist last ready
-    raw_node.on_persist_ready(number);
-    let res = raw_node.light_ready();
+    let res = raw_node.on_persist_last_ready();
     assert_eq!(res.commit_index(), Some(first_index + 100));
     assert_eq!(
         res.committed_entries().first().unwrap().get_index(),
@@ -1181,12 +1179,10 @@ fn test_async_ready_leader() {
             assert_eq!(msg.get_commit(), first_index + 9);
         }
     }
-    let number = rd.number();
     raw_node.advance_append_async(rd);
 
     // Forward commit index due to peer 1's append response and persisted entries
-    raw_node.on_persist_ready(number);
-    let res = raw_node.light_ready();
+    let res = raw_node.on_persist_last_ready();
     assert_eq!(res.commit_index(), Some(first_index + 10));
     assert_eq!(
         res.committed_entries().first().unwrap().get_index(),
@@ -1263,11 +1259,9 @@ fn test_async_ready_follower() {
             }
         }
         assert_eq!(msg_num, 4);
-        let number = rd.number();
         raw_node.advance_append_async(rd);
 
-        raw_node.on_persist_ready(number);
-        let mut res = raw_node.light_ready();
+        let mut res = raw_node.on_persist_last_ready();
         assert_eq!(res.commit_index(), None);
         assert_eq!(
             res.committed_entries().first().unwrap().get_index(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,9 +251,9 @@ entries but has not been committed yet, we must append the entries to the Raft l
     # }
     # let mut ready = node.ready();
     #
-    if !ready.entries().is_empty() {
+    if !ready.entries.is_empty() {
         // Append entries to the Raft log
-        node.mut_store().wl().append(ready.entries()).unwrap();
+        node.mut_store().wl().append(&ready.entries).unwrap();
     }
 
     ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,7 +354,7 @@ We must persist the changed `HardState`:
     }
     ```
 
-6. Call `advance` to notify that the previous work is completed. Get the return value `PersistLastReadyResult`
+6. Call `advance` to notify that the previous work is completed. Get the return value `LightReady`
 and handle its `messages` and `committed_entries` like step 1 and step 3 does. Then call `advance_apply`
 to advance the applied index inside.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,10 +379,10 @@ to advance the applied index inside.
     #
     # fn handle_committed_entries(committed_entries: Vec<Entry>) {
     # }
-    let mut res = node.advance(ready);
+    let mut light_rd = node.advance(ready);
     // Like step 1 and 5, you can use functions to make them behave the same.
-    handle_messages(res.take_messages());
-    handle_committed_entries(res.take_committed_entries());
+    handle_messages(light_rd.take_messages());
+    handle_committed_entries(light_rd.take_committed_entries());
     node.advance_apply();
     ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,7 +505,7 @@ pub use self::tracker::{Inflights, Progress, ProgressState, ProgressTracker};
 
 #[allow(deprecated)]
 pub use self::raw_node::is_empty_snap;
-pub use self::raw_node::{Peer, RawNode, Ready, SnapshotStatus};
+pub use self::raw_node::{LightReady, Peer, RawNode, Ready, SnapshotStatus};
 pub use self::read_only::{ReadOnlyOption, ReadState};
 pub use self::status::Status;
 pub use self::storage::{RaftState, Storage};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,84 @@ let mut ready = node.ready();
 The `Ready` state contains quite a bit of information, and you need to check and process them one
 by one:
 
-1. Check whether `snapshot` is empty or not. If not empty, it means that the Raft node has received
+1. Check whether `messages` is empty or not. If not, it means that the node will send messages to
+other nodes:
+
+    ```rust
+    # use slog::{Drain, o};
+    # use raft::{Config, storage::MemStorage, raw_node::RawNode, StateRole};
+    #
+    # let config = Config { id: 1, ..Default::default() };
+    # config.validate().unwrap();
+    # let store = MemStorage::new_with_conf_state((vec![1], vec![]));
+    # let logger = slog::Logger::root(slog_stdlog::StdLog.fuse(), o!());
+    # let mut node = RawNode::new(&config, store, &logger).unwrap();
+    #
+    # if !node.has_ready() {
+    #   return;
+    # }
+    # let mut ready = node.ready();
+    # let is_leader = node.raft.state == StateRole::Leader;
+    #
+    let msgs = ready.take_messages();
+    for vec_msg in msgs {
+        for _msg in vec_msg {
+            // Send messages to other peers.
+        }
+    }
+    ```
+
+2. Check whether `hs` is empty or not. If not empty, it means that the `HardState` of the node has
+changed. For example, the node may vote for a new leader, or the commit index has been increased.
+We must persist the changed `HardState`:
+
+    ```rust
+    # use slog::{Drain, o};
+    # use raft::{Config, storage::MemStorage, raw_node::RawNode};
+    #
+    # let config = Config { id: 1, ..Default::default() };
+    # config.validate().unwrap();
+    # let store = MemStorage::new_with_conf_state((vec![1], vec![]));
+    # let logger = slog::Logger::root(slog_stdlog::StdLog.fuse(), o!());
+    # let mut node = RawNode::new(&config, store, &logger).unwrap();
+    #
+    # if !node.has_ready() {
+    #   return;
+    # }
+    # let mut ready = node.ready();
+    #
+    if let Some(hs) = ready.hs() {
+        // Raft HardState changed, and we need to persist it.
+        node.mut_store().wl().set_hardstate(hs.clone());
+    }
+    ```
+
+3. Check whether `entries` is empty or not. If not empty, it means that there are newly added
+entries but has not been committed yet, we must append the entries to the Raft log:
+
+    ```rust
+    # use slog::{Drain, o};
+    # use raft::{Config, storage::MemStorage, raw_node::RawNode};
+    #
+    # let config = Config { id: 1, ..Default::default() };
+    # config.validate().unwrap();
+    # let store = MemStorage::new_with_conf_state((vec![1], vec![]));
+    # let logger = slog::Logger::root(slog_stdlog::StdLog.fuse(), o!());
+    # let mut node = RawNode::new(&config, store, &logger).unwrap();
+    #
+    # if !node.has_ready() {
+    #   return;
+    # }
+    # let mut ready = node.ready();
+    #
+    if !ready.entries().is_empty() {
+        // Append entries to the Raft log
+        node.mut_store().wl().append(ready.entries()).unwrap();
+    }
+
+    ```
+
+4. Check whether `snapshot` is empty or not. If not empty, it means that the Raft node has received
 a Raft snapshot from the leader and we must apply the snapshot:
 
     ```rust
@@ -231,89 +308,6 @@ a Raft snapshot from the leader and we must apply the snapshot:
             .unwrap();
     }
 
-    ```
-
-2. Check whether `entries` is empty or not. If not empty, it means that there are newly added
-entries but has not been committed yet, we must append the entries to the Raft log:
-
-    ```rust
-    # use slog::{Drain, o};
-    # use raft::{Config, storage::MemStorage, raw_node::RawNode};
-    #
-    # let config = Config { id: 1, ..Default::default() };
-    # config.validate().unwrap();
-    # let store = MemStorage::new_with_conf_state((vec![1], vec![]));
-    # let logger = slog::Logger::root(slog_stdlog::StdLog.fuse(), o!());
-    # let mut node = RawNode::new(&config, store, &logger).unwrap();
-    #
-    # if !node.has_ready() {
-    #   return;
-    # }
-    # let mut ready = node.ready();
-    #
-    if !ready.entries().is_empty() {
-        // Append entries to the Raft log
-        node.mut_store().wl().append(ready.entries()).unwrap();
-    }
-
-    ```
-
-3. Check whether `hs` is empty or not. If not empty, it means that the `HardState` of the node has
-changed. For example, the node may vote for a new leader, or the commit index has been increased.
-We must persist the changed `HardState`:
-
-    ```rust
-    # use slog::{Drain, o};
-    # use raft::{Config, storage::MemStorage, raw_node::RawNode};
-    #
-    # let config = Config { id: 1, ..Default::default() };
-    # config.validate().unwrap();
-    # let store = MemStorage::new_with_conf_state((vec![1], vec![]));
-    # let logger = slog::Logger::root(slog_stdlog::StdLog.fuse(), o!());
-    # let mut node = RawNode::new(&config, store, &logger).unwrap();
-    #
-    # if !node.has_ready() {
-    #   return;
-    # }
-    # let mut ready = node.ready();
-    #
-    if let Some(hs) = ready.hs() {
-        // Raft HardState changed, and we need to persist it.
-        node.mut_store().wl().set_hardstate(hs.clone());
-    }
-    ```
-
-4. Check whether `messages` is empty or not. If not, it means that the node will send messages to
-other nodes. There has been an optimization for sending messages: if the node is a leader, this can
-be done together with step 1 in parallel; if the node is not a leader, it needs to reply the
-messages to the leader after appending the Raft entries:
-
-    ```rust
-    # use slog::{Drain, o};
-    # use raft::{Config, storage::MemStorage, raw_node::RawNode, StateRole};
-    #
-    # let config = Config { id: 1, ..Default::default() };
-    # config.validate().unwrap();
-    # let store = MemStorage::new_with_conf_state((vec![1], vec![]));
-    # let logger = slog::Logger::root(slog_stdlog::StdLog.fuse(), o!());
-    # let mut node = RawNode::new(&config, store, &logger).unwrap();
-    #
-    # if !node.has_ready() {
-    #   return;
-    # }
-    # let mut ready = node.ready();
-    # let is_leader = node.raft.state == StateRole::Leader;
-    #
-    if !is_leader {
-        // If not leader, the follower needs to reply the messages to
-        // the leader after appending Raft entries.
-        let msgs = ready.take_messages();
-        for vec_msg in msgs {
-            for _msg in vec_msg {
-                // Send messages to other peers.
-            }
-        }
-    }
     ```
 
 5. Check whether `committed_entires` is empty or not. If not, it means that there are some newly
@@ -360,11 +354,13 @@ need to update the applied index and resume `apply` later:
     }
     ```
 
-6. Call `advance` to prepare for the next `Ready` state.
+6. Call `advance` to prepare for the next `Ready` state. Get the return value `PersistLastReadyResult`
+and handle its `messages` and `committed_entries` like step 1 and step 5 does.
 
     ```rust
     # use slog::{Drain, o};
-    # use raft::{Config, storage::MemStorage, raw_node::RawNode, eraftpb::EntryType};
+    # use raft::{Config, storage::MemStorage, raw_node::RawNode};
+    # use raft::eraftpb::{EntryType, Entry, Message};
     #
     # let config = Config { id: 1, ..Default::default() };
     # config.validate().unwrap();
@@ -377,7 +373,15 @@ need to update the applied index and resume `apply` later:
     # }
     # let mut ready = node.ready();
     #
-    node.advance(ready);
+    # fn handle_messages(msgs: Vec<Vec<Message>>) {
+    # }
+    #
+    # fn handle_committed_entries(committed_entries: Vec<Entry>) {
+    # }
+    let mut res = node.advance(ready);
+    // Like step 1 and 5, you can use functions to make them behave the same.
+    handle_messages(res.take_messages());
+    handle_committed_entries(res.take_committed_entries());
     ```
 
 For more information, check out an [example](examples/single_mem_node/main.rs#L113-L179).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,7 @@ need to update the applied index and resume `apply` later:
     ```
 
 4. Check whether `entries` is empty or not. If not empty, it means that there are newly added
-entries but has not been committed yet, we must append the entries to the Raft log:
+entries but have not been committed yet, we must append the entries to the Raft log:
 
     ```rust
     # use slog::{Drain, o};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,8 +354,9 @@ need to update the applied index and resume `apply` later:
     }
     ```
 
-6. Call `advance` to prepare for the next `Ready` state. Get the return value `PersistLastReadyResult`
-and handle its `messages` and `committed_entries` like step 1 and step 5 does.
+6. Call `advance` to notify that the previous work is completed. Get the return value `PersistLastReadyResult`
+and handle its `messages` and `committed_entries` like step 1 and step 5 does. Then call `advance_apply` 
+to advance the applied index inside.
 
     ```rust
     # use slog::{Drain, o};
@@ -382,6 +383,7 @@ and handle its `messages` and `committed_entries` like step 1 and step 5 does.
     // Like step 1 and 5, you can use functions to make them behave the same.
     handle_messages(res.take_messages());
     handle_committed_entries(res.take_committed_entries());
+    node.advance_apply();
     ```
 
 For more information, check out an [example](examples/single_mem_node/main.rs#L113-L179).

--- a/src/log_unstable.rs
+++ b/src/log_unstable.rs
@@ -85,8 +85,9 @@ impl Unstable {
         }
     }
 
-    /// Returns all entries and moves the stable offset up to the last index(if any).
-    pub fn stable_all(&mut self) -> Vec<Entry> {
+    /// Returns the unstable entries and moves the stable offset up to the
+    /// last index, if there is any.
+    pub fn stable_entries(&mut self) -> Vec<Entry> {
         if self.entries.is_empty() {
             return Vec::new();
         }
@@ -94,29 +95,9 @@ impl Unstable {
         std::mem::take(&mut self.entries)
     }
 
-    /// Moves the stable offset up to the index. Provided that the index
-    /// is in the same election term.
-    pub fn stable_to(&mut self, idx: u64, term: u64) {
-        let t = self.maybe_term(idx);
-        if t.is_none() {
-            return;
-        }
-
-        if t.unwrap() == term && idx >= self.offset {
-            let start = idx + 1 - self.offset;
-            self.entries.drain(..start as usize);
-            self.offset = idx + 1;
-        }
-    }
-
-    /// Removes the snapshot from self if the index of the snapshot matches
-    pub fn stable_snap_to(&mut self, idx: u64) {
-        if self.snapshot.is_none() {
-            return;
-        }
-        if idx == self.snapshot.as_ref().unwrap().get_metadata().index {
-            self.snapshot = None;
-        }
+    /// Returns the snapshot and removes it from self.
+    pub fn stable_snap(&mut self) -> Option<Snapshot> {
+        self.snapshot.take()
     }
 
     /// From a given snapshot, restores the snapshot to self, but doesn't unpack.
@@ -339,82 +320,18 @@ mod test {
     }
 
     #[test]
-    fn test_stable_to() {
-        // entries, offset, snap, index, term, woffset, wlen
-        let tests = vec![
-            (vec![], 0, None, 5, 1, 0, 0),
-            // stable to the first entry
-            (vec![new_entry(5, 1)], 5, None, 5, 1, 6, 0),
-            (vec![new_entry(5, 1), new_entry(6, 0)], 5, None, 5, 1, 6, 1),
-            // stable to the first entry and term mismatch
-            (vec![new_entry(6, 2)], 5, None, 6, 1, 5, 1),
-            // stable to old entry
-            (vec![new_entry(5, 1)], 5, None, 4, 1, 5, 1),
-            (vec![new_entry(5, 1)], 5, None, 4, 2, 5, 1),
-            // with snapshot
-            // stable to the first entry
-            (
-                vec![new_entry(5, 1)],
-                5,
-                Some(new_snapshot(4, 1)),
-                5,
-                1,
-                6,
-                0,
-            ),
-            // stable to the first entry
-            (
-                vec![new_entry(5, 1), new_entry(6, 1)],
-                5,
-                Some(new_snapshot(4, 1)),
-                5,
-                1,
-                6,
-                1,
-            ),
-            // stable to the first entry and term mismatch
-            (
-                vec![new_entry(6, 2)],
-                5,
-                Some(new_snapshot(5, 1)),
-                6,
-                1,
-                5,
-                1,
-            ),
-            // stable to snapshot
-            (
-                vec![new_entry(5, 1)],
-                5,
-                Some(new_snapshot(4, 1)),
-                4,
-                1,
-                5,
-                1,
-            ),
-            // stable to old entry
-            (
-                vec![new_entry(5, 2)],
-                5,
-                Some(new_snapshot(4, 2)),
-                4,
-                1,
-                5,
-                1,
-            ),
-        ];
-
-        for (entries, offset, snapshot, index, term, woffset, wlen) in tests {
-            let mut u = Unstable {
-                entries,
-                offset,
-                snapshot,
-                logger: crate::default_logger(),
-            };
-            u.stable_to(index, term);
-            assert_eq!(u.offset, woffset);
-            assert_eq!(u.entries.len(), wlen);
-        }
+    fn test_stable_entries() {
+        let ents = vec![new_entry(5, 1), new_entry(5, 2), new_entry(6, 3)];
+        let mut u = Unstable {
+            entries: ents.clone(),
+            offset: 5,
+            snapshot: Some(new_snapshot(4, 1)),
+            logger: crate::default_logger(),
+        };
+        let unstable = u.stable_entries();
+        assert_eq!(ents, unstable);
+        assert!(u.entries.is_empty());
+        assert_eq!(u.offset, 7);
     }
 
     #[test]

--- a/src/log_unstable.rs
+++ b/src/log_unstable.rs
@@ -85,6 +85,15 @@ impl Unstable {
         }
     }
 
+    /// Returns all entries and moves the stable offset up to the last index(if any).
+    pub fn stable_all(&mut self) -> Vec<Entry> {
+        if self.entries.is_empty() {
+            return Vec::new();
+        }
+        self.offset = self.entries.last().unwrap().get_index() + 1;
+        std::mem::take(&mut self.entries)
+    }
+
     /// Moves the stable offset up to the index. Provided that the index
     /// is in the same election term.
     pub fn stable_to(&mut self, idx: u64, term: u64) {

--- a/src/log_unstable.rs
+++ b/src/log_unstable.rs
@@ -85,19 +85,18 @@ impl Unstable {
         }
     }
 
-    /// Returns the unstable entries and moves the stable offset up to the
+    /// Clears the unstable entries and moves the stable offset up to the
     /// last index, if there is any.
-    pub fn stable_entries(&mut self) -> Vec<Entry> {
-        if self.entries.is_empty() {
-            return Vec::new();
+    pub fn stable_entries(&mut self) {
+        if let Some(entry) = self.entries.last() {
+            self.offset = entry.get_index() + 1;
+            self.entries.clear();
         }
-        self.offset = self.entries.last().unwrap().get_index() + 1;
-        std::mem::take(&mut self.entries)
     }
 
-    /// Returns the snapshot and removes it from self.
-    pub fn stable_snap(&mut self) -> Option<Snapshot> {
-        self.snapshot.take()
+    /// Clears the unstable snapshot.
+    pub fn stable_snap(&mut self) {
+        self.snapshot = None;
     }
 
     /// From a given snapshot, restores the snapshot to self, but doesn't unpack.
@@ -328,8 +327,8 @@ mod test {
             snapshot: Some(new_snapshot(4, 1)),
             logger: crate::default_logger(),
         };
-        let unstable = u.stable_entries();
-        assert_eq!(ents, unstable);
+        assert_eq!(ents, u.entries);
+        u.stable_entries();
         assert!(u.entries.is_empty());
         assert_eq!(u.offset, 7);
     }

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -967,7 +967,7 @@ impl<T: Storage> Raft<T> {
         }
         self.raft_log.append(es);
 
-        // Not move on self's pr.matched until on_persist_entries
+        // Not update self's pr.matched until on_persist_entries
         true
     }
 

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -235,7 +235,9 @@ impl<T: Storage> Raft<T> {
     pub fn new(c: &Config, store: T, logger: &Logger) -> Result<Self> {
         c.validate()?;
         let logger = logger.new(o!("raft_id" => c.id));
-        let raft_state = store.initial_state()?;
+        let mut raft_state = store.initial_state()?;
+        // If commit index is smaller than applied index, forward it.
+        raft_state.hard_state.commit = cmp::max(raft_state.hard_state.commit, c.applied);
         let conf_state = &raft_state.conf_state;
         let voters = &conf_state.voters;
         let learners = &conf_state.learners;

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -235,9 +235,7 @@ impl<T: Storage> Raft<T> {
     pub fn new(c: &Config, store: T, logger: &Logger) -> Result<Self> {
         c.validate()?;
         let logger = logger.new(o!("raft_id" => c.id));
-        let mut raft_state = store.initial_state()?;
-        // If commit index is smaller than applied index, forward it.
-        raft_state.hard_state.commit = cmp::max(raft_state.hard_state.commit, c.applied);
+        let raft_state = store.initial_state()?;
         let conf_state = &raft_state.conf_state;
         let voters = &conf_state.voters;
         let learners = &conf_state.learners;

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -971,7 +971,7 @@ impl<T: Storage> Raft<T> {
         true
     }
 
-    /// Notifies that raft_log has been well persisted
+    /// Notifies that these raft logs have been well persisted.
     pub fn on_persist_entries(&mut self, index: u64, term: u64) {
         let update = self.raft_log.maybe_persist(index, term);
         if update && self.state == StateRole::Leader {
@@ -982,6 +982,11 @@ impl<T: Storage> Raft<T> {
                 self.bcast_append();
             }
         }
+    }
+
+    /// Notifies that this snapshot has been persisted.
+    pub fn on_persist_snap(&mut self, index: u64, term: u64) {
+        self.raft_log.maybe_persist(index, term);
     }
 
     /// Returns true to indicate that there will probably be some readiness need to be handled.

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -984,11 +984,6 @@ impl<T: Storage> Raft<T> {
         }
     }
 
-    /// Notifies that this snapshot has been persisted.
-    pub fn on_persist_snap(&mut self, index: u64, term: u64) {
-        self.raft_log.maybe_persist(index, term);
-    }
-
     /// Returns true to indicate that there will probably be some readiness need to be handled.
     pub fn tick(&mut self) -> bool {
         match self.state {

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1125,7 +1125,12 @@ impl<T: Storage> Raft<T> {
         self.state = StateRole::Leader;
 
         let last_index = self.raft_log.last_index();
-
+        // If there is only one peer, it becomes leader after starting
+        // so all logs must be persisted.
+        // If not, it becomes leader after sending RequestVote msg.
+        // Since all logs must be persisted before sending RequestVote
+        // msg and logs can not be changed when it's (pre)candidate, the
+        // last index is equal to persisted index when it becomes leader.
         assert_eq!(last_index, self.raft_log.persisted);
 
         // Update uncommitted state

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -696,7 +696,10 @@ mod test {
         for i in unstable_index..last_index {
             raft_log.append(&[new_entry(i as u64 + 1, i as u64 + 1)]);
         }
-
+        assert!(
+            raft_log.maybe_persist(last_index, last_term),
+            "maybe_persist return false"
+        );
         assert!(
             raft_log.maybe_commit(last_index, last_term),
             "maybe_commit return false"
@@ -946,6 +949,7 @@ mod test {
             store.wl().apply_snapshot(new_snapshot(3, 1)).expect("");
             let mut raft_log = RaftLog::new(store, l.clone());
             raft_log.append(&ents);
+            raft_log.maybe_persist(5, 1);
             raft_log.maybe_commit(5, 1);
             #[allow(deprecated)]
             raft_log.applied_to(applied);
@@ -971,6 +975,7 @@ mod test {
             store.wl().apply_snapshot(new_snapshot(3, 1)).expect("");
             let mut raft_log = RaftLog::new(store, l.clone());
             raft_log.append(&ents);
+            raft_log.maybe_persist(5, 1);
             raft_log.maybe_commit(5, 1);
             #[allow(deprecated)]
             raft_log.applied_to(applied);

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -453,11 +453,10 @@ impl<T: Storage> RaftLog<T> {
     /// Attempts to persist the index and term and returns whether it did.
     pub fn maybe_persist(&mut self, index: u64, term: u64) -> bool {
         // It's possible that the term check can be passed but index is
-        // less than the unstable's offset in corner cases.
-        // We handle these issues by not forwarding the persisted index.
-        // It's pretty intuitive because there are a snapshot or some entries
-        // whose index is greater than the unstable's offset has not been
-        // persisted yet.
+        // greater than or equal to the unstable's offset in some corner cases.
+        // We handle these issues by not forwarding the persisted index. It's
+        // pretty intuitive because the offset means there are some entries
+        // whose index is greater than the offset has not been persisted yet.
         if index > self.persisted
             && index < self.unstable.offset
             && self.term(index).map_or(false, |t| t == term)

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -354,12 +354,24 @@ impl<T: Storage> RaftLog<T> {
         term > self.last_term() || (term == self.last_term() && last_index >= self.last_index())
     }
 
-    /// Returns any entries since the a particular index.
-    pub fn next_entries_since(&self, since_idx: u64) -> Option<Vec<Entry>> {
-        let offset = cmp::max(since_idx + 1, self.first_index());
-        let committed = self.committed;
-        if committed + 1 > offset {
-            match self.slice(offset, committed + 1, None) {
+    /// Returns any entries between the `since_idx`(if none, use applied) 
+    /// and the min(`persisted_idx`(if any), commit index) + 1.
+    pub fn next_entries_between(
+        &self,
+        since_idx: Option<u64>,
+        persisted_idx: Option<u64>,
+    ) -> Option<Vec<Entry>> {
+        let idx = match since_idx {
+            Some(idx) => idx,
+            None => self.applied,
+        };
+        let offset = cmp::max(idx + 1, self.first_index());
+        let high = match persisted_idx {
+            Some(persisted_idx) => cmp::min(persisted_idx, self.committed) + 1,
+            None => self.committed + 1,
+        };
+        if high > offset {
+            match self.slice(offset, high, None) {
                 Ok(vec) => return Some(vec),
                 Err(e) => fatal!(self.unstable.logger, "{}", e),
             }
@@ -371,18 +383,27 @@ impl<T: Storage> RaftLog<T> {
     /// If applied is smaller than the index of snapshot, it returns all committed
     /// entries after the index of snapshot.
     pub fn next_entries(&self) -> Option<Vec<Entry>> {
-        self.next_entries_since(self.applied)
+        self.next_entries_between(None, None)
     }
 
-    /// Returns whether there are entries that can be applied between `since_idx` and the comitted index.
-    pub fn has_next_entries_since(&self, since_idx: u64) -> bool {
-        let offset = cmp::max(since_idx + 1, self.first_index());
-        self.committed + 1 > offset
+    /// Returns whether there are entries that can be applied between the `since_idx`(if none, use applied) 
+    /// and the min(`persisted_idx`(if any), commit index) + 1.
+    pub fn has_next_entries_between(&self, since_idx: Option<u64>, persisted_idx: Option<u64>) -> bool {
+        let idx = match since_idx {
+            Some(idx) => idx,
+            None => self.applied,
+        };
+        let offset = cmp::max(idx + 1, self.first_index());
+        let high = match persisted_idx {
+            Some(persisted_idx) => cmp::min(persisted_idx, self.committed) + 1,
+            None => self.committed + 1,
+        };
+        high > offset
     }
 
     /// Returns whether there are new entries.
     pub fn has_next_entries(&self) -> bool {
-        self.has_next_entries_since(self.applied)
+        self.has_next_entries_between(None, None)
     }
 
     /// Returns the current snapshot

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -924,9 +924,6 @@ mod test {
         assert!(!raft_log.maybe_persist(102, 1));
     }
 
-    #[test]
-    fn test_restore_() {}
-
     // TestUnstableEnts ensures unstableEntries returns the unstable part of the
     // entries correctly.
     #[test]

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -364,8 +364,7 @@ impl<T: Storage> RaftLog<T> {
         term > self.last_term() || (term == self.last_term() && last_index >= self.last_index())
     }
 
-    /// Returns any entries between max(`since_idx` + 1, first_index)
-    /// and min(persisted, committed).
+    /// Returns committed and persisted entries since max(`since_idx` + 1, first_index).
     pub fn next_entries_since(&self, since_idx: u64) -> Option<Vec<Entry>> {
         let offset = cmp::max(since_idx + 1, self.first_index());
         let high = cmp::min(self.persisted, self.committed) + 1;
@@ -385,8 +384,8 @@ impl<T: Storage> RaftLog<T> {
         self.next_entries_since(self.applied)
     }
 
-    /// Returns whether there are entries that can be applied between
-    /// max(`since_idx` + 1, first_index) and min(persisted, committed).
+    /// Returns whether there are committed and persisted entries since
+    /// max(`since_idx` + 1, first_index).
     pub fn has_next_entries_since(&self, since_idx: u64) -> bool {
         let offset = cmp::max(since_idx + 1, self.first_index());
         let high = cmp::min(self.persisted, self.committed) + 1;

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -37,6 +37,8 @@ pub struct RaftLog<T: Storage> {
 
     /// The highest log position that is known to be in stable storage
     /// on a quorum of nodes.
+    ///
+    /// Invariant: applied <= committed
     pub committed: u64,
 
     /// The highest log position that is known to be persisted in stable
@@ -49,7 +51,7 @@ pub struct RaftLog<T: Storage> {
     /// The highest log position that the application has been instructed
     /// to apply to its state machine.
     ///
-    /// Invariant: applied <= committed
+    /// Invariant: applied <= min(committed, persisted)
     pub applied: u64,
 }
 

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -355,7 +355,7 @@ impl<T: Storage> RaftLog<T> {
     }
 
     /// Returns any entries between max(`since_idx` + 1, first_index)
-    /// and min(`persisted_idx`, committed) + 1.
+    /// and min(`persisted_idx`, committed).
     pub fn next_entries_between(&self, since_idx: u64, persisted_idx: u64) -> Option<Vec<Entry>> {
         let offset = cmp::max(since_idx + 1, self.first_index());
         let high = cmp::min(persisted_idx, self.committed) + 1;
@@ -376,7 +376,7 @@ impl<T: Storage> RaftLog<T> {
     }
 
     /// Returns whether there are entries that can be applied between
-    /// max(`since_idx` + 1, first_index) and min(`persisted_idx`, committed) + 1.
+    /// max(`since_idx` + 1, first_index) and min(`persisted_idx`, committed).
     pub fn has_next_entries_between(&self, since_idx: u64, persisted_idx: u64) -> bool {
         let offset = cmp::max(since_idx + 1, self.first_index());
         let high = cmp::min(persisted_idx, self.committed) + 1;

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -354,7 +354,7 @@ impl<T: Storage> RaftLog<T> {
         term > self.last_term() || (term == self.last_term() && last_index >= self.last_index())
     }
 
-    /// Returns any entries between the `since_idx`(if none, use applied) 
+    /// Returns any entries between the `since_idx`(if none, use applied)
     /// and the min(`persisted_idx`(if any), commit index) + 1.
     pub fn next_entries_between(
         &self,
@@ -386,9 +386,13 @@ impl<T: Storage> RaftLog<T> {
         self.next_entries_between(None, None)
     }
 
-    /// Returns whether there are entries that can be applied between the `since_idx`(if none, use applied) 
+    /// Returns whether there are entries that can be applied between the `since_idx`(if none, use applied)
     /// and the min(`persisted_idx`(if any), commit index) + 1.
-    pub fn has_next_entries_between(&self, since_idx: Option<u64>, persisted_idx: Option<u64>) -> bool {
+    pub fn has_next_entries_between(
+        &self,
+        since_idx: Option<u64>,
+        persisted_idx: Option<u64>,
+    ) -> bool {
         let idx = match since_idx {
             Some(idx) => idx,
             None => self.applied,

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -586,6 +586,7 @@ impl<T: Storage> RawNode<T> {
     ///
     /// Returns the LightReady that contains commit index, committed entries and messages. `LightReady`
     /// contains updates that only valid after persisting last ready. It should also be fully processed.
+    /// Then `advance_apply` or `advance_apply_to` should be used later to update applying progress.
     pub fn advance(&mut self, rd: Ready) -> LightReady {
         let applied = self.commit_since_index;
         let light_rd = self.advance_append(rd);
@@ -593,7 +594,8 @@ impl<T: Storage> RawNode<T> {
         light_rd
     }
 
-    /// Advances the ready without applying committed entries.
+    /// Advances the ready without applying committed entries. `advance_apply` or `advance_apply_to`
+    /// should be used later to update applying progress.
     ///
     /// Returns the LightReady that contains commit index, committed entries and messages.
     ///

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -432,7 +432,7 @@ impl<T: Storage> RawNode<T> {
         }
 
         if !raft.read_states.is_empty() {
-            rd.read_states = mem::take(&mut raft.read_states);
+            mem::swap(&mut rd.read_states, &mut raft.read_states);
         }
 
         if raft.raft_log.unstable.snapshot.is_some() {
@@ -473,7 +473,7 @@ impl<T: Storage> RawNode<T> {
         }
 
         if !self.messages.is_empty() {
-            rd.messages = mem::take(&mut self.messages);
+            mem::swap(&mut rd.messages, &mut self.messages);
         }
         if !raft.msgs.is_empty() {
             if raft.state == StateRole::Leader {
@@ -481,7 +481,7 @@ impl<T: Storage> RawNode<T> {
                 // For more details, check raft thesis 10.2.1.
                 rd.messages.push(mem::take(&mut raft.msgs));
             } else {
-                rd_record.messages = mem::take(&mut raft.msgs);
+                mem::swap(&mut rd_record.messages, &mut raft.msgs);
             }
         }
         self.records.push_back(rd_record);
@@ -529,8 +529,8 @@ impl<T: Storage> RawNode<T> {
     }
 
     fn commit_ready(&mut self, rd: Ready) {
-        if rd.ss.is_some() {
-            self.prev_ss = rd.ss.unwrap();
+        if let Some(ss) = rd.ss {
+            self.prev_ss = ss;
         }
         if let Some(hs) = rd.hs {
             if hs != HardState::default() {
@@ -615,7 +615,7 @@ impl<T: Storage> RawNode<T> {
         }
 
         if !self.messages.is_empty() {
-            res.messages = mem::take(&mut self.messages);
+            mem::swap(&mut res.messages, &mut self.messages);
         }
 
         if !raft.msgs.is_empty() && raft.state == StateRole::Leader {

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -379,6 +379,7 @@ impl<T: Storage> RawNode<T> {
         Err(Error::StepPeerNotFound)
     }
 
+    /// Generates a LightReady that has the committed entries and messages but no commit index.
     fn gen_light_ready(&mut self) -> LightReady {
         let mut rd = LightReady::default();
         let raft = &mut self.raft;

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -262,9 +262,9 @@ pub struct RawNode<T: Storage> {
     records: VecDeque<ReadyRecord>,
     // If there is a pending snapshot.
     pending_snapshot: bool,
-    // Index which the given committed entries should start from
+    // Index which the given committed entries should start from.
     commit_since_index: u64,
-    // Messages that need to be sent to other peers
+    // Messages that need to be sent to other peers.
     messages: Vec<Vec<Message>>,
 }
 

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -498,6 +498,7 @@ impl<T: Storage> RawNode<T> {
         if !raft.msgs.is_empty() || !self.messages.is_empty() {
             return true;
         }
+
         if raft.soft_state() != self.prev_ss {
             return true;
         }
@@ -523,7 +524,7 @@ impl<T: Storage> RawNode<T> {
         {
             return true;
         }
-        
+
         false
     }
 
@@ -612,14 +613,11 @@ impl<T: Storage> RawNode<T> {
             assert!(hard_state.commit == self.prev_hs.commit);
             light_rd.commit_index = None;
         }
-        assert_eq!(
-            hard_state, self.prev_hs,
-            "hard state != prev_hs",
-        );
+        assert_eq!(hard_state, self.prev_hs, "hard state != prev_hs",);
         light_rd
     }
 
-    /// Same as `advance_append` except that it allows to only store the updates in cache. `on_persist_ready` 
+    /// Same as `advance_append` except that it allows to only store the updates in cache. `on_persist_ready`
     /// should be used later to update the persisting progress.
     ///
     /// Raft works on an assumption persisted updates should not be lost, which usually requires expensive

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -439,6 +439,7 @@ impl<T: Storage> RawNode<T> {
             rd.read_states = mem::take(&mut raft.read_states);
         }
 
+        // If there is a snapshot, committed entries should not be given.
         if raft.raft_log.unstable.snapshot.is_some() {
             rd.snapshot = raft.raft_log.unstable.snapshot.clone().unwrap();
             rd_record.snapshot = rd.snapshot.clone();

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -541,10 +541,11 @@ impl<T: Storage> RawNode<T> {
     /// Since Ready must be persisted in order, calling this function implicitly means
     /// all readys with numbers smaller than this have been persisted.
     pub fn on_persist_ready(&mut self, number: u64) {
-        while let Some(record) = self.records.pop_front() {
+        while let Some(record) = self.records.front() {
             if record.number > number {
                 break;
             }
+            let record = self.records.pop_front().unwrap();
             if let Some(last_log) = record.last_entry {
                 self.raft.on_persist_entries(last_log.0, last_log.1);
                 self.last_persisted_index = last_log.0;

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -455,7 +455,7 @@ impl<T: Storage> RawNode<T> {
 
         if let Some(snapshot) = &raft.raft_log.unstable_snapshot() {
             rd.snapshot = snapshot.clone();
-            assert!(self.commit_since_index < rd.snapshot.get_metadata().index);
+            assert!(self.commit_since_index <= rd.snapshot.get_metadata().index);
             self.commit_since_index = rd.snapshot.get_metadata().index;
             // If there is a snapshot, the latter entries can not be persisted
             // so there is no committed entries.

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -639,8 +639,6 @@ impl<T: Storage> RawNode<T> {
     pub fn advance(&mut self, rd: Ready) -> PersistLastReadyResult {
         let applied = self.commit_since_index;
         let res = self.advance_append(rd);
-        // The `advance_apply` may add a new entry so it should be called
-        // after `advance_append`.
         self.advance_apply_to(applied);
         res
     }


### PR DESCRIPTION
## Description
In the past, ready must be used synchronously. It means the application must persist some data in ready and then it can be allowed to get the next ready. 
As https://github.com/etcd-io/etcd/issues/12257 mentioned:

> 1. it can cause high fsync frequency. In the practice of TiKV, we observed the fsync frequency can reach the limit of hardware very easily, which can cause unstable latency and hurt performance. Also high fsync frequency is also expensive in the cloud.
> 2. sync size is unpredictable, which can waste IO when syncing small data size.

This PR aims to support asynchronous ready.

First of all, this PR changes the ready workflow and divides it into two types, i.e. sync and async.

The expected sync ready workflow is

```
1. get ready
2. handle ready
    1. send msg(need not to wait for persisting entries)
    2. apply committed entries(need not to wait for persisting entries) or snapshot
    3. handle read_state, persist hard state and entries
3. if application applies committed entries synchronously, call `advance`, otherwise call `advance_append`
(call `advance_apply_to` after applying). These two functions return LightReady
4. handle LightReady
    1. send msg
    2. apply committed entries
    3. update commit index to hardstate if any
5. call `advance_apply` if applying synchronously
5. get next ready, back to step 1
```

The expected async ready workflow is

```
1. get ready
2. handle ready
    1. send msg(need not to wait for persisting entries)
    2. apply committed_entries(need not to wait for persisting entries) or snapshot
    3. handle read_state, persist hardstate and entries(need not to wait for success)
3. record the number of the ready and call `advance_append_async`
    * if this ready has been persisted synchronously, call `advance_append` instead 
      of `advance_append_async` to get LightReady and then handle it
4. get next ready, back to step 1

If a ready has been persisted, call `on_persist_ready` and pass the number.
```

Actually, not just for the async ready, this PR can also decrease the latency of the sync ready.

```
According to the previous manual, the application must apply committed entries after it has persisted hard state and entries. 
Think of this case:

1. leader gets a new proposal
2. get ready
    1. persist the entries and send append msg to followers
3. leader gets some append response and this proposal can be committed
4. get ready
    1. persist the hard state(for commit index)
    2. apply committed entries

We can find out that leader should wait for two persistences before really applying. 
The latter one is just for persisting a commit index.
Now step 4 can be 
1. apply committed entries
2. persist the hard state(for commit index)
So the latency can be shorter than before.

Note that if this machine crashes before persisting the hard state, the applied index will be greater than the commit index in hard state. 
We will discuss it next.
```


There are some subtle implementation details:
1. The commit index can be smaller than applied index which is impossible in previous implementation. Although commit index persistence has one correctness dependency for conf change(Append Invariant https://github.com/etcd-io/etcd/issues/7625#issuecomment-489232411), the behavior here(i.e. make apply earlier) does not break it. I use the max(hard_state.commit, applied) as the commit index during initialization.
2. The leader forwards `matched` of its progress when a log is proposed. In previous implementation, it's correct because we need to persist entries and then send msg to others. But now it's not correct so the `matched` of leader's progress can be forward after calling `on_persist_ready`.
3. All of the committed entries must be persisted so `persisted` is maintained and it's used for fetching the committed entries(as the upper bound).
4. Remove the `ready_since` and `has_ready_since` and use `commit_since_index` instead. It's also used for fetching the committed entries(as the lower bound).
5. Since `matched` logic is changed and `persisted` is added, some tests are failed.  The method I chose is to add a `persist` function in `Interface` and call it in `Network::send` and some other places.

## Remaining Work
- [x] Update two examples
- [x] Add more tests for async ready
- [ ] Add doc for async ready(I will do this in next PR)