### PR TITLE
Fix examples and snapshot code of MemStorageCore

### DIFF
--- a/examples/five_mem_node/main.rs
+++ b/examples/five_mem_node/main.rs
@@ -327,7 +327,7 @@ fn on_ready(
     let mut light_rd = raft_group.advance(ready);
     // Update commit index.
     if let Some(commit) = light_rd.commit_index() {
-        store.wl().mut_hard_state().set_commit(commit); 
+        store.wl().mut_hard_state().set_commit(commit);
     }
     // Send out the messages.
     handle_messages(light_rd.take_messages());

--- a/examples/five_mem_node/main.rs
+++ b/examples/five_mem_node/main.rs
@@ -325,6 +325,10 @@ fn on_ready(
 
     // Call `RawNode::advance` interface to update position flags in the raft.
     let mut light_rd = raft_group.advance(ready);
+    // Update commit index.
+    if let Some(commit) = light_rd.commit_index() {
+        store.wl().mut_hard_state().set_commit(commit); 
+    }
     // Send out the messages.
     handle_messages(light_rd.take_messages());
     // Apply all committed entries.

--- a/examples/single_mem_node/main.rs
+++ b/examples/single_mem_node/main.rs
@@ -164,7 +164,7 @@ fn on_ready(raft_group: &mut RawNode<MemStorage>, cbs: &mut HashMap<u8, ProposeC
     let mut light_rd = raft_group.advance(ready);
     // Update commit index.
     if let Some(commit) = light_rd.commit_index() {
-        store.wl().mut_hard_state().set_commit(commit); 
+        store.wl().mut_hard_state().set_commit(commit);
     }
     // Send out the messages.
     handle_messages(light_rd.take_messages());

--- a/examples/single_mem_node/main.rs
+++ b/examples/single_mem_node/main.rs
@@ -162,6 +162,10 @@ fn on_ready(raft_group: &mut RawNode<MemStorage>, cbs: &mut HashMap<u8, ProposeC
 
     // Advance the Raft.
     let mut light_rd = raft_group.advance(ready);
+    // Update commit index.
+    if let Some(commit) = light_rd.commit_index() {
+        store.wl().mut_hard_state().set_commit(commit); 
+    }
     // Send out the messages.
     handle_messages(light_rd.take_messages());
     // Apply all committed entries.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -212,7 +212,7 @@ impl MemStorageCore {
     fn snapshot(&self) -> Snapshot {
         let mut snapshot = Snapshot::default();
 
-        // We assume all entries whose index is less than hard_state.commit 
+        // We assume all entries whose index is less than hard_state.commit
         // has been applied yet.
         // So use the latest commit_idx to construct the snapshot.
         // TODO: This is not true for async ready.
@@ -225,7 +225,10 @@ impl MemStorageCore {
             let offset = self.entries[0].index;
             self.entries[(meta.index - offset) as usize].term
         } else {
-            panic!("commit {} < snapshot_metadata.index {}", meta.index, self.snapshot_metadata.index);
+            panic!(
+                "commit {} < snapshot_metadata.index {}",
+                meta.index, self.snapshot_metadata.index
+            );
         };
 
         meta.set_conf_state(self.raft_state.conf_state.clone());

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -214,9 +214,8 @@ impl MemStorageCore {
     fn snapshot(&self) -> Snapshot {
         let mut snapshot = Snapshot::default();
 
-        // We assume all entries whose index is less than hard_state.commit
-        // has been applied yet.
-        // So use the latest commit_idx to construct the snapshot.
+        // We assume all entries whose indexes are less than `hard_state.commit`
+        // have been applied, so use the latest commit index to construct the snapshot.
         // TODO: This is not true for async ready.
         let meta = snapshot.mut_metadata();
         meta.index = self.raft_state.hard_state.commit;


### PR DESCRIPTION
Signed-off-by: gengliqi <gengliqiii@gmail.com>

Issue: close https://github.com/tikv/raft-rs/issues/408

The commit index of `LightReady` is not handled in examples.
But the test can not pass is mainly due to the bug of generating snapshot in `MemStorageCore`.
The term in snapshot meta should not be the `hard_state.term`. It should be the log term of `meta.index`.

By the way, the snapshot has an assumption that all entries whose index is less than `hard_state.commit` has been applied, which is not true when using async ready. So I leave a TODO and I will resolve it soon.