### PR TITLE
Change the behavior of persisted index for snapshot

### DIFF
--- a/harness/src/interface.rs
+++ b/harness/src/interface.rs
@@ -60,7 +60,9 @@ impl Interface {
                 let snap = snapshot.clone();
                 self.raft_log.stable_snap();
                 let index = snap.get_metadata().index;
+                let term = snap.get_metadata().term;
                 self.mut_store().wl().apply_snapshot(snap).expect("");
+                self.on_persist_entries(index, term);
                 self.commit_apply(index);
             }
             let unstable = self.raft_log.unstable_entries().to_vec();

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -1325,7 +1325,7 @@ fn test_async_ready_follower() {
         true,
         true,
     );
-    
+
     s.wl().set_hardstate(rd.hs().unwrap().clone());
     s.wl().apply_snapshot(snapshot).unwrap();
     s.wl().append(rd.entries()).unwrap();
@@ -1365,16 +1365,7 @@ fn test_async_ready_follower() {
     raw_node.on_persist_ready(rd_number + 2);
 
     let rd = raw_node.ready();
-    must_cmp_ready(
-        &rd,
-        &None,
-        &None,
-        &[],
-        &entries[..3],
-        &None,
-        false,
-        false,
-    );
+    must_cmp_ready(&rd, &None, &None, &[], &entries[..3], &None, false, false);
 }
 
 /// Test if a new leader immediately sends all messages recorded before without

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -1221,7 +1221,7 @@ fn test_async_ready_leader() {
 }
 
 /// Test if async ready process is expected when a follower receives
-/// some append msg.
+/// some append msg and snapshot.
 #[test]
 fn test_async_ready_follower() {
     let l = default_logger();
@@ -1232,7 +1232,7 @@ fn test_async_ready_follower() {
 
     let mut raw_node = new_raw_node(1, vec![1, 2], 10, 1, s.clone(), &l);
     let mut first_index = 1;
-    let mut rd_number = 1;
+    let mut rd_number = 0;
     for cnt in 0..3 {
         for i in 0..10 {
             let entries = [
@@ -1253,7 +1253,7 @@ fn test_async_ready_follower() {
             raw_node.step(append_msg).unwrap();
 
             let rd = raw_node.ready();
-            assert_eq!(rd.number(), rd_number + i);
+            assert_eq!(rd.number(), rd_number + i + 1);
             assert_eq!(rd.hs(), Some(&hard_state(2, first_index + i * 3 + 3, 0)));
             assert_eq!(rd.entries(), &entries);
             assert_eq!(rd.committed_entries().as_slice(), &[]);
@@ -1264,7 +1264,7 @@ fn test_async_ready_follower() {
             raw_node.advance_append_async(rd);
         }
         // Unpersisted Ready number in range [1, 10]
-        raw_node.on_persist_ready(rd_number + 3);
+        raw_node.on_persist_ready(rd_number + 4);
         let mut rd = raw_node.ready();
         assert_eq!(rd.hs(), None);
         assert_eq!(
@@ -1306,6 +1306,75 @@ fn test_async_ready_follower() {
         first_index += 10 * 3;
         rd_number += 11;
     }
+
+    let snapshot = new_snapshot(first_index + 5, 2, vec![1, 2]);
+    let mut snapshot_msg = new_message(2, 1, MessageType::MsgSnapshot, 0);
+    snapshot_msg.set_term(2);
+    snapshot_msg.set_snapshot(snapshot.clone());
+    raw_node.step(snapshot_msg).unwrap();
+
+    let rd = raw_node.ready();
+    assert_eq!(rd.number(), rd_number + 1);
+    must_cmp_ready(
+        &rd,
+        &None,
+        &Some(hard_state(2, first_index + 5, 0)),
+        &[],
+        &[],
+        &Some(snapshot.clone()),
+        true,
+        true,
+    );
+    
+    s.wl().set_hardstate(rd.hs().unwrap().clone());
+    s.wl().apply_snapshot(snapshot).unwrap();
+    s.wl().append(rd.entries()).unwrap();
+    raw_node.advance_append_async(rd);
+
+    let mut entries = vec![];
+    for i in 1..10 {
+        entries.push(new_entry(2, first_index + 5 + i, Some("hello")));
+    }
+    let mut append_msg = new_message_with_entries(2, 1, MessageType::MsgAppend, entries.to_vec());
+    append_msg.set_term(2);
+    append_msg.set_index(first_index + 5);
+    append_msg.set_log_term(2);
+    append_msg.set_commit(first_index + 5 + 3);
+    raw_node.step(append_msg).unwrap();
+
+    let rd = raw_node.ready();
+    assert_eq!(rd.number(), rd_number + 2);
+    must_cmp_ready(
+        &rd,
+        &None,
+        &Some(hard_state(2, first_index + 5 + 3, 0)),
+        &entries,
+        &[],
+        &None,
+        true,
+        true,
+    );
+    s.wl().set_hardstate(rd.hs().unwrap().clone());
+    s.wl().append(rd.entries()).unwrap();
+    raw_node.advance_append_async(rd);
+
+    raw_node.on_persist_ready(rd_number + 1);
+    assert_eq!(raw_node.raft.raft_log.persisted, first_index + 5);
+    raw_node.advance_apply_to(first_index + 5);
+
+    raw_node.on_persist_ready(rd_number + 2);
+
+    let rd = raw_node.ready();
+    must_cmp_ready(
+        &rd,
+        &None,
+        &None,
+        &[],
+        &entries[..3],
+        &None,
+        false,
+        false,
+    );
 }
 
 /// Test if a new leader immediately sends all messages recorded before without

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -971,7 +971,7 @@ impl<T: Storage> Raft<T> {
         true
     }
 
-    /// Notifies that these raft logs have been well persisted.
+    /// Notifies that these raft logs or snapshot have been persisted.
     pub fn on_persist_entries(&mut self, index: u64, term: u64) {
         let update = self.raft_log.maybe_persist(index, term);
         if update && self.state == StateRole::Leader {

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -977,7 +977,7 @@ impl<T: Storage> Raft<T> {
         // Actually, if it is a leader and persisted index is updated, this term
         // must be equal to self.term because the persisted index must be equal to
         // the last index of entries from previous leader when it becomes leader
-        // (see the comments in become_leader), namely, the new persisted entries 
+        // (see the comments in become_leader), namely, the new persisted entries
         // must come from this leader. Here checking the term just for robustness.
         if update && self.state == StateRole::Leader && term == self.term {
             let self_id = self.id;

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -974,7 +974,12 @@ impl<T: Storage> Raft<T> {
     /// Notifies that these raft logs or snapshot have been persisted.
     pub fn on_persist_entries(&mut self, index: u64, term: u64) {
         let update = self.raft_log.maybe_persist(index, term);
-        if update && self.state == StateRole::Leader {
+        // Actually, if it is a leader and persisted index is updated, this term
+        // must be equal to self.term because the persisted index must be equal to
+        // the last index of entries from previous leader when it becomes leader
+        // (see the comments in become_leader), namely, the new persisted entries 
+        // must come from this leader. Here checking the term just for robustness.
+        if update && self.state == StateRole::Leader && term == self.term {
             let self_id = self.id;
             let pr = self.mut_prs().get_mut(self_id).unwrap();
             pr.maybe_update(index);
@@ -1125,7 +1130,7 @@ impl<T: Storage> Raft<T> {
         self.state = StateRole::Leader;
 
         let last_index = self.raft_log.last_index();
-        // If there is only one peer, it becomes leader after starting
+        // If there is only one peer, it becomes leader after campaigning
         // so all logs must be persisted.
         // If not, it becomes leader after sending RequestVote msg.
         // Since all logs must be persisted before sending RequestVote

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -538,7 +538,7 @@ impl<T: Storage> RaftLog<T> {
         let index = snapshot.get_metadata().index;
         assert!(index >= self.committed, "{} < {}", index, self.committed);
         // If `persisted` is greater than `committed`, reset it to `committed`.
-        // It's because only the persisted entries whose index are less than `commited` can be 
+        // It's because only the persisted entries whose index are less than `commited` can be
         // considered the same as the data from snapshot.
         // Although there may be some persisted entries with greater index are also committed,
         // we can not judge them nor do we care about them because these entries can not be applied

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -538,10 +538,6 @@ impl<T: Storage> RaftLog<T> {
         let index = snapshot.get_metadata().index;
         assert!(index >= self.committed, "{} < {}", index, self.committed);
         self.committed = index;
-        // persisted is just used for fetching committed entries.
-        // Here reset the persisted to index to satisfy its invariant which is
-        // persisted < unstable.offset and applied <= persisted.
-        self.persisted = index;
         self.unstable.restore(snapshot);
     }
 }
@@ -765,7 +761,6 @@ mod test {
         let mut raft_log = RaftLog::new(store, default_logger());
         raft_log.restore(new_snapshot(unstablesnapi, 1));
         assert_eq!(raft_log.committed, unstablesnapi);
-        assert_eq!(raft_log.persisted, unstablesnapi);
 
         let tests = vec![
             // cannot get term from storage
@@ -1521,7 +1516,7 @@ mod test {
         assert_eq!(raft_log.persisted, 100);
         raft_log.restore(new_snapshot(200, 1));
         assert_eq!(raft_log.committed, 200);
-        assert_eq!(raft_log.persisted, 200);
+        assert_eq!(raft_log.persisted, 100);
 
         for i in 201..210 {
             raft_log.append(&[new_entry(i, 1)]);
@@ -1536,13 +1531,10 @@ mod test {
         raft_log.stable_entries();
         raft_log.mut_store().wl().append(&unstable).expect("");
         raft_log.maybe_persist(209, 1);
-
         assert_eq!(raft_log.persisted, 209);
 
         raft_log.restore(new_snapshot(205, 1));
         assert_eq!(raft_log.committed, 205);
-        // persisted should backward to 205
-        assert_eq!(raft_log.persisted, 205);
 
         // use smaller commit index, should panic
         assert!(


### PR DESCRIPTION
Signed-off-by: gengliqi <gengliqiii@gmail.com>

In previous async ready PR(https://github.com/tikv/raft-rs/pull/403), After getting a snapshot and calling the `restore` function, the `persisted` is changed to the index of this snapshot. This makes the `persisted` index does not mean the data before this index is _really_ persisted, which is not intuitive.
The reason for this behavior is to maintain a invariant that `applied <= min(committed, persisted)`. However, I find it's not needed if the application calls the `advance_append` or `on_persist_ready` then calls `advance_apply_to`. This is intuitive because the snapshot is persisted does not mean it is applied so it should be persisted first, then be applied.