### PR TITLE
*: allow vote to inform log commit

### DIFF
--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -23,6 +23,7 @@ use protobuf::Message as PbMessage;
 use raft::eraftpb::*;
 use raft::storage::MemStorage;
 use raft::*;
+use raft_proto::*;
 use slog::Logger;
 
 use crate::integration_cases::test_raft_paper::commit_noop_entry;
@@ -4466,6 +4467,209 @@ fn test_conf_change_check_before_campaign() {
         nt.peers.get_mut(&1).unwrap().tick();
     }
     assert_eq!(nt.peers[&1].state, StateRole::Candidate);
+}
+
+/// Tests the commit index can be advanced by vote request
+#[test]
+fn test_advance_commit_index_by_vote_request() {
+    let l = default_logger();
+    let mut cases: Vec<Box<dyn ConfChangeI>> = vec![];
+    cases.push(Box::new(conf_change(ConfChangeType::AddNode, 4)));
+    cases.push(Box::new(conf_change_v2(vec![
+        new_conf_change_single(3, ConfChangeType::AddLearnerNode),
+        new_conf_change_single(4, ConfChangeType::AddNode),
+    ])));
+    for (i, cc) in cases.drain(..).enumerate() {
+        let peers = (1..=4).map(|id| Some(new_test_learner_raft(id, vec![1, 2, 3], vec![4], 10, 1, new_storage(), &l))).collect();
+        let mut nt = Network::new(peers, &l);
+        nt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
+        let mut e = Entry::default();
+        if let Some(v1) = cc.as_v1() {
+            e.set_entry_type(EntryType::EntryConfChange);
+            e.set_data(v1.write_to_bytes().unwrap());
+        } else {
+            e.set_entry_type(EntryType::EntryConfChangeV2);
+            e.set_data(cc.as_v2().write_to_bytes().unwrap());
+        }
+        
+        // propose a confchange entry but don't let it commit
+        nt.ignore(MessageType::MsgAppendResponse);
+        nt.send(vec![new_message_with_entries(1, 1, MessageType::MsgPropose, vec![e])]);
+        let cc_index = nt.peers[&1].raft_log.last_index();
+
+        // let node 4 have more up to data log than other voter
+        nt.recover();
+        nt.cut(1, 2);
+        nt.cut(1, 3);
+        nt.send(vec![new_message(1, 1, MessageType::MsgPropose, 1)]);
+        
+        // let the confchange entry commit but don't let node 4 know
+        nt.recover();
+        nt.cut(1, 4);
+        nt.ignore(MessageType::MsgAppend);
+        let mut msg = new_message(2, 1, MessageType::MsgAppendResponse, 0);
+        msg.set_index(nt.peers[&2].raft_log.last_index());
+        nt.send(vec![msg, new_message(1, 1, MessageType::MsgBeat, 0)]);
+        
+        // simulate the leader down
+        nt.recover();
+        nt.isolate(1);
+
+        let p4 = nt.peers.get_mut(&4).unwrap();
+        if p4.raft_log.committed >= cc_index {
+            panic!("#{} expected node 4 commit index less than {}, got {}", i, cc_index, p4.raft_log.committed);
+        }
+        // node 4 can't start new election because it thinks itself is a learner
+        for _ in 0..p4.randomized_election_timeout() {
+            p4.tick();
+        }
+        if p4.state != StateRole::Follower {
+            panic!("#{} node 4 state: {:?}, want Follower", i, p4.state);
+        }
+        let p2 = nt.peers.get_mut(&2).unwrap();
+        if p2.raft_log.committed < cc_index {
+            panic!("#{} expected node 2 commit index not less than {}, got {}", i, cc_index, p2.raft_log.committed);
+        }
+        p2.apply_conf_change(&cc.as_v2()).unwrap();
+        p2.commit_apply(cc_index);
+
+        // node 2 needs votes from both node 3 and node 4, but node 4 will reject it
+        for _ in 0..p2.randomized_election_timeout() {
+            p2.tick();
+        }
+        if p2.state != StateRole::Candidate {
+            panic!("#{} node 2 state: {:?}, want Candidate", i, p2.state);
+        }
+        let msgs = nt.read_messages();
+        nt.filter_and_send(msgs);
+        if nt.peers[&2].state != StateRole::Leader {
+            panic!("#{} node 2 can't campaign successfully.");
+        }
+
+        // node 4's commit index should be advanced by node 2's vote request
+        let p4 = nt.peers.get_mut(&4).unwrap();
+        if p4.raft_log.committed < cc_index {
+            panic!("#{} expected node 4 commit index not less than {}, got {}", i, cc_index, p4.raft_log.committed);
+        }
+        p4.apply_conf_change(&cc.as_v2()).unwrap();
+        p4.commit_apply(cc_index);
+
+        // now node 4 can start new election and become leader
+        for _ in 0..p4.randomized_election_timeout() {
+            p4.tick();
+        }
+        let msgs = nt.read_messages();
+        nt.filter_and_send(msgs);
+        if nt.peers[&4].state != StateRole::Leader {
+            panic!("#{} node 4 state: {:?} want Leader", i, nt.peers[&4].state);
+        }
+    }
+}
+
+// Tests the commit index can be forwarded by vote response
+#[test]
+fn test_advance_commit_index_by_vote_response() {
+    let l = default_logger();
+    let mut cases: Vec<Box<dyn ConfChangeI>> = vec![];
+    cases.push(Box::new(conf_change(ConfChangeType::RemoveNode, 4)));
+    // Explicit leave joint
+    cases.push(Box::new(conf_change_v2(vec![])));
+    // Enter joint confchange
+    let mut enter_joint = conf_change_v2(vec![
+        new_conf_change_single(3, ConfChangeType::AddNode),
+        new_conf_change_single(4, ConfChangeType::AddLearnerNode),
+    ]);
+    enter_joint.set_transition(ConfChangeTransition::Explicit);
+    for (i, cc) in cases.drain(..).enumerate() {
+        let mut nt = Network::new(vec![None, None, None, None], &l);
+
+        // Joint confchange, let's enter joint first
+        if cc.as_v1().is_none() {
+            for p in nt.peers.values_mut() {
+                p.apply_conf_change(&enter_joint).unwrap();
+            }
+        }
+        
+        nt.send(vec![new_message(1, 1, MessageType::MsgHup, 0)]);
+
+        let mut e = Entry::default();
+        if let Some(v1) = cc.as_v1() {
+            e.set_entry_type(EntryType::EntryConfChange);
+            e.set_data(v1.write_to_bytes().unwrap());
+        } else {
+            e.set_entry_type(EntryType::EntryConfChangeV2);
+            e.set_data(cc.as_v2().write_to_bytes().unwrap());
+        }
+        
+        // propose a confchange entry but don't let it commit
+        nt.ignore(MessageType::MsgAppendResponse);
+        nt.send(vec![new_message_with_entries(1, 1, MessageType::MsgPropose, vec![e])]);
+        let cc_index = nt.peers[&1].raft_log.last_index();
+
+        // let node 4 have more up to data log than other voter
+        nt.recover();
+        nt.cut(1, 2);
+        nt.cut(1, 3);
+        nt.send(vec![new_message(1, 1, MessageType::MsgPropose, 1)]);
+        
+        // A delayed MsgAppResp message make the confchange entry become committed
+        let mut msg = new_message(2, 1, MessageType::MsgAppendResponse, 0);
+        msg.set_index(nt.peers[&2].raft_log.last_index());
+        nt.send(vec![msg, new_message(1, 1, MessageType::MsgBeat, 0)]);
+
+        // simulate the leader down
+        nt.recover();
+        nt.isolate(1);
+
+        let p4 = nt.peers.get_mut(&4).unwrap();
+        if p4.raft_log.committed < cc_index {
+            panic!("#{} expected node 4 commit index larger than {}, got {}", i, cc_index, p4.raft_log.committed);
+        }
+        p4.apply_conf_change(&cc.as_v2()).unwrap();
+        p4.commit_apply(cc_index);
+        // node 4 can't start new election because it thinks itself is a learner
+        for _ in 0..p4.randomized_election_timeout() {
+            p4.tick();
+        }
+        if p4.state != StateRole::Follower {
+            panic!("#{} node 4 state: {:?}, want Follower", i, p4.state);
+        }
+        let p2 = nt.peers.get_mut(&2).unwrap();
+        if p2.raft_log.committed >= cc_index {
+            panic!("#{} expected node 2 commit index less than {}, got {}", i, cc_index, p2.raft_log.committed);
+        }
+
+        // node 2 needs votes from both node 3 and node 4, but node 4 will reject it
+        for _ in 0..p2.randomized_election_timeout() {
+            p2.tick();
+        }
+        if p2.state != StateRole::Candidate {
+            panic!("#{} node 2 state: {:?}, want Candidate", i, p2.state);
+        }
+        let msgs = nt.read_messages();
+        nt.filter_and_send(msgs);
+        let p2 = nt.peers.get_mut(&2).unwrap();
+        if p2.state != StateRole::Follower {
+            panic!("#{} node 2 should become follower by vote response, but got {:?}", i, p2.state);
+        }
+        
+        // node 2's commit index should be advanced by vote response
+        if p2.raft_log.committed < cc_index {
+            panic!("#{} expected node 2 commit index less than {}, got {}", i, cc_index, p2.raft_log.committed);
+        }
+        p2.apply_conf_change(&cc.as_v2()).unwrap();
+        p2.commit_apply(cc_index);
+        
+        // now node 2 only need vote from node 3
+        for _ in 0..p2.randomized_election_timeout() {
+            p2.tick();
+        }
+        let msgs = nt.read_messages();
+        nt.filter_and_send(msgs);
+        if nt.peers[&2].state != StateRole::Leader {
+            panic!("#{} node 2 state: {:?} want Leader", i, nt.peers[&2].state);
+        }
+    }
 }
 
 fn prepare_request_snapshot() -> (Network, Snapshot) {

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -4581,7 +4581,7 @@ fn test_advance_commit_index_by_vote_request(use_prevote: bool) {
         let msgs = nt.read_messages();
         nt.filter_and_send(msgs);
         if nt.peers[&2].state == StateRole::Leader {
-            panic!("#{} node 2 can't campaign successfully.");
+            panic!("#{} node 2 can't campaign successfully.", i);
         }
 
         // node 4's commit index should be advanced by node 2's vote request

--- a/harness/tests/test_util/mod.rs
+++ b/harness/tests/test_util/mod.rs
@@ -212,6 +212,10 @@ pub fn conf_state_v2(
     cs
 }
 
+pub fn conf_change(t: ConfChangeType, node_id: u64) -> ConfChange {
+    new_conf_change(t, node_id)
+}
+
 pub fn conf_change_v2(steps: Vec<ConfChangeSingle>) -> ConfChangeV2 {
     let mut cc = ConfChangeV2::default();
     cc.set_changes(steps.into());

--- a/harness/tests/test_util/mod.rs
+++ b/harness/tests/test_util/mod.rs
@@ -172,7 +172,7 @@ pub fn new_snapshot(index: u64, term: u64, voters: Vec<u64>) -> Snapshot {
     s
 }
 
-fn new_conf_change(ty: ConfChangeType, node_id: u64) -> ConfChange {
+pub fn conf_change(ty: ConfChangeType, node_id: u64) -> ConfChange {
     let mut cc = ConfChange::default();
     cc.node_id = node_id;
     cc.set_change_type(ty);
@@ -180,15 +180,15 @@ fn new_conf_change(ty: ConfChangeType, node_id: u64) -> ConfChange {
 }
 
 pub fn remove_node(node_id: u64) -> ConfChangeV2 {
-    new_conf_change(ConfChangeType::RemoveNode, node_id).into_v2()
+    conf_change(ConfChangeType::RemoveNode, node_id).into_v2()
 }
 
 pub fn add_node(node_id: u64) -> ConfChangeV2 {
-    new_conf_change(ConfChangeType::AddNode, node_id).into_v2()
+    conf_change(ConfChangeType::AddNode, node_id).into_v2()
 }
 
 pub fn add_learner(node_id: u64) -> ConfChangeV2 {
-    new_conf_change(ConfChangeType::AddLearnerNode, node_id).into_v2()
+    conf_change(ConfChangeType::AddLearnerNode, node_id).into_v2()
 }
 
 pub fn conf_state(voters: Vec<u64>, learners: Vec<u64>) -> ConfState {
@@ -210,10 +210,6 @@ pub fn conf_state_v2(
     cs.set_learners_next(learners_next);
     cs.auto_leave = auto_leave;
     cs
-}
-
-pub fn conf_change(t: ConfChangeType, node_id: u64) -> ConfChange {
-    new_conf_change(t, node_id)
 }
 
 pub fn conf_change_v2(steps: Vec<ConfChangeSingle>) -> ConfChangeV2 {

--- a/proto/proto/eraftpb.proto
+++ b/proto/proto/eraftpb.proto
@@ -74,6 +74,7 @@ message Message {
     uint64 index = 6;
     repeated Entry entries = 7;
     uint64 commit = 8;
+    uint64 commit_term = 15;
     Snapshot snapshot = 9;
     uint64 request_snapshot = 13;
     bool reject = 10;

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1434,7 +1434,7 @@ impl<T: Storage> Raft<T> {
                     self.r.send(to_send, &mut self.msgs);
                     // It should be safe to commit log by vote in all conditions as long as it's
                     // not leader. Here use a stricter condition for best safety.
-                    if self.leader_id == INVALID_ID {
+                    if self.leader_id == INVALID_ID || !self.promotable {
                         self.maybe_commit_by_vote(&m);
                     }
                 }

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1205,6 +1205,7 @@ impl<T: Storage> Raft<T> {
             return;
         }
 
+        let (commit, commit_term) = self.raft_log.commit_info();
         let mut voters = [0; 7];
         let mut voter_cnt = 0;
 
@@ -1224,6 +1225,8 @@ impl<T: Storage> Raft<T> {
             m.term = term;
             m.index = self.raft_log.last_index();
             m.log_term = self.raft_log.last_term();
+            m.commit = commit;
+            m.commit_term = commit_term;
             if campaign_type == CAMPAIGN_TRANSFER {
                 m.context = campaign_type.to_vec();
             }
@@ -1347,7 +1350,7 @@ impl<T: Storage> Raft<T> {
                 let to_send = new_message(m.from, MessageType::MsgAppendResponse, None);
                 self.r.send(to_send, &mut self.msgs);
             } else if m.get_msg_type() == MessageType::MsgRequestPreVote {
-                // Before pre_vote enable, there may be a recieving candidate with higher term,
+                // Before pre_vote enable, there may be a receiving candidate with higher term,
                 // but less log. After update to pre_vote, the cluster may deadlock if
                 // we drop messages with a lower term.
                 info!(
@@ -1425,7 +1428,15 @@ impl<T: Storage> Raft<T> {
                         new_message(m.from, vote_resp_msg_type(m.get_msg_type()), None);
                     to_send.reject = true;
                     to_send.term = self.term;
+                    let (commit, commit_term) = self.raft_log.commit_info();
+                    to_send.commit = commit;
+                    to_send.commit_term = commit_term;
                     self.r.send(to_send, &mut self.msgs);
+                    // It should be safe to commit log by vote in all conditions as long as it's
+                    // not leader. Here use a stricter condition for best safety.
+                    if self.leader_id == INVALID_ID {
+                        self.maybe_commit_by_vote(&m);
+                    }
                 }
             }
             _ => match self.state {
@@ -1966,6 +1977,27 @@ impl<T: Storage> Raft<T> {
         Ok(())
     }
 
+    /// Commits the logs using commit info in vote message.
+    ///
+    /// If commit index is updated, true is returned.
+    fn maybe_commit_by_vote(&mut self, m: &Message) -> bool {
+        if m.commit == 0 || m.commit_term == 0 {
+            return false;
+        }
+        if m.commit <= self.raft_log.committed || self.state == StateRole::Leader {
+            return false;
+        }
+        if !self.raft_log.match_term(m.commit, m.commit_term) {
+            return false;
+        }
+
+        let log = &mut self.r.raft_log;
+        info!(self.r.logger, "[commit: {}, lastindex: {}, lastterm: {}] fast-forwarded commit to vote request [index: {}, term: {}]",
+                log.committed, log.last_index(), log.last_term(), m.commit, m.commit_term);
+        log.commit_to(m.commit);
+        true
+    }
+
     fn poll(&mut self, from: u64, t: MessageType, vote: bool) -> VoteResult {
         self.prs.record_vote(from, vote);
         let (gr, rj, res) = self.prs.tally_votes();
@@ -2043,6 +2075,27 @@ impl<T: Storage> Raft<T> {
                 }
 
                 self.poll(m.from, m.get_msg_type(), !m.reject);
+                let last_commit = self.raft_log.committed;
+                if self.maybe_commit_by_vote(&m) && self.state != StateRole::Follower {
+                    let ents = self
+                        .raft_log
+                        .slice(last_commit + 1, self.raft_log.committed + 1, None)
+                        .unwrap_or_else(|e| {
+                            fatal!(
+                                self.logger,
+                                "unexpected error getting unapplied entries [{}, {}): {:?}",
+                                last_commit + 1,
+                                self.raft_log.committed + 1,
+                                e
+                            );
+                        });
+                    if self.num_pending_conf(&ents) != 0 {
+                        // The candidate doesn't have to step down in theory, here just for best
+                        // safety as we assume quorum won't change during election.
+                        let term = self.term;
+                        self.become_follower(term, INVALID_ID);
+                    }
+                }
             }
             MessageType::MsgTimeoutNow => debug!(
                 self.logger,

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1432,8 +1432,8 @@ impl<T: Storage> Raft<T> {
                     to_send.commit = commit;
                     to_send.commit_term = commit_term;
                     self.r.send(to_send, &mut self.msgs);
-                    // It should be safe to commit log by vote in all conditions as long as it's
-                    // not leader. Here use a stricter condition for best safety.
+                    // It should be safe to commit log by vote in all conditions. Here
+                    // use a stricter condition for best safety.
                     if self.leader_id == INVALID_ID || !self.promotable {
                         self.maybe_commit_by_vote(&m);
                     }

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1432,11 +1432,7 @@ impl<T: Storage> Raft<T> {
                     to_send.commit = commit;
                     to_send.commit_term = commit_term;
                     self.r.send(to_send, &mut self.msgs);
-                    // It should be safe to commit log by vote in all conditions. Here
-                    // use a stricter condition for best safety.
-                    if self.leader_id == INVALID_ID || !self.promotable {
-                        self.maybe_commit_by_vote(&m);
-                    }
+                    self.maybe_commit_by_vote(&m);
                 }
             }
             _ => match self.state {

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -549,6 +549,19 @@ impl<T: Storage> RaftLog<T> {
         self.committed = index;
         self.unstable.restore(snapshot);
     }
+
+    /// Returns the committed index and its term.
+    pub fn commit_info(&self) -> (u64, u64) {
+        match self.term(self.committed) {
+            Ok(t) => (self.committed, t),
+            Err(e) => fatal!(
+                self.unstable.logger,
+                "last committed entry at {} is missing: {:?}",
+                self.committed,
+                e
+            ),
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is a port of etcd-io/etcd#12435. I made some adaption, notable
changes are:
- Candidate steps down as follower when new commit logs contains conf
change.
- Allow log commit only when a node has no leader.

Those changes are not necessary in theory, but I add them for best
safety.