### PR TITLE
update to prost 0.7

### DIFF
--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -22,5 +22,5 @@ protobuf-build = { version = "0.11", default-features = false }
 
 [dependencies]
 lazy_static = { version = "1", optional = true }
-prost = { version = "0.6", optional = true }
+prost = { version = "0.7", optional = true }
 protobuf = "2"


### PR DESCRIPTION
prost 0.7 was [released](https://github.com/danburkert/prost/releases/tag/v0.7.0).

Signed-off-by: Ron Cohen <cohen1@gmail.com>