### PR TITLE
fix persisted index bug of snapshot

### DIFF
--- a/benches/suites/raw_node.rs
+++ b/benches/suites/raw_node.rs
@@ -108,7 +108,7 @@ fn test_ready_raft_node(logger: &slog::Logger) -> RawNode<MemStorage> {
     node.raft.become_candidate();
     node.raft.become_leader();
     let unstable = node.raft.raft_log.unstable_entries().to_vec();
-    node.raft.raft_log.stable_entries();
+    node.raft.raft_log.stable_entries(1, 1);
     node.raft.raft_log.store.wl().append(&unstable).expect("");
     node.raft.on_persist_entries(1, 1);
     node.raft.commit_apply(1);
@@ -123,12 +123,10 @@ fn test_ready_raft_node(logger: &slog::Logger) -> RawNode<MemStorage> {
     }
     let _ = node.raft.append_entry(&mut entries);
     let unstable = node.raft.raft_log.unstable_entries().to_vec();
-    node.raft.raft_log.stable_entries();
+    node.raft.raft_log.stable_entries(101, 1);
     node.raft.raft_log.store.wl().append(&unstable).expect("");
-    node.raft.raft_log.stable_entries();
     // This increases 'committed_index' to `last_index` because there is only one node in quorum.
-    node.raft
-        .on_persist_entries(node.raft.raft_log.last_index(), 1);
+    node.raft.on_persist_entries(101, 1);
 
     let mut snap = Snapshot::default();
     snap.set_data(vec![0; 8 * 1024 * 1024]);

--- a/harness/src/interface.rs
+++ b/harness/src/interface.rs
@@ -58,18 +58,18 @@ impl Interface {
         if self.raft.is_some() {
             if let Some(snapshot) = self.raft_log.unstable_snapshot() {
                 let snap = snapshot.clone();
-                self.raft_log.stable_snap();
                 let index = snap.get_metadata().index;
+                self.raft_log.stable_snap(index);
                 self.mut_store().wl().apply_snapshot(snap).expect("");
                 self.on_persist_snap(index);
                 self.commit_apply(index);
             }
             let unstable = self.raft_log.unstable_entries().to_vec();
-            if !unstable.is_empty() {
-                self.raft_log.stable_entries();
-                let last_entry = unstable.last().unwrap();
+            if let Some(e) = unstable.last() {
+                let (last_idx, last_term) = (e.get_index(), e.get_term());
+                self.raft_log.stable_entries(last_idx, last_term);
                 self.mut_store().wl().append(&unstable).expect("");
-                self.on_persist_entries(last_entry.index, last_entry.term);
+                self.on_persist_entries(last_idx, last_term);
             }
         }
     }

--- a/harness/src/interface.rs
+++ b/harness/src/interface.rs
@@ -60,9 +60,8 @@ impl Interface {
                 let snap = snapshot.clone();
                 self.raft_log.stable_snap();
                 let index = snap.get_metadata().index;
-                let term = snap.get_metadata().term;
                 self.mut_store().wl().apply_snapshot(snap).expect("");
-                self.on_persist_entries(index, term);
+                self.on_persist_snap(index);
                 self.commit_apply(index);
             }
             let unstable = self.raft_log.unstable_entries().to_vec();

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -468,7 +468,7 @@ fn test_raw_node_propose_add_duplicate_node() {
     raw_node.campaign().expect("");
     loop {
         let rd = raw_node.ready();
-        s.wl().append(rd.entries()).expect("");
+        s.wl().append(rd.entries()).unwrap();
         if rd.ss().map_or(false, |ss| ss.leader_id == raw_node.raft.id) {
             let _ = raw_node.advance(rd);
             break;
@@ -530,7 +530,7 @@ fn test_raw_node_propose_add_learner_node() -> Result<()> {
     raw_node.campaign().expect("");
     loop {
         let rd = raw_node.ready();
-        s.wl().append(rd.entries()).expect("");
+        s.wl().append(rd.entries()).unwrap();
         if rd.ss().map_or(false, |ss| ss.leader_id == raw_node.raft.id) {
             let _ = raw_node.advance(rd);
             break;
@@ -580,7 +580,7 @@ fn test_raw_node_read_index() {
     raw_node.campaign().expect("");
     loop {
         let rd = raw_node.ready();
-        s.wl().append(rd.entries()).expect("");
+        s.wl().append(rd.entries()).unwrap();
         if rd.ss().map_or(false, |ss| ss.leader_id == raw_node.raft.id) {
             let _ = raw_node.advance(rd);
 
@@ -799,6 +799,8 @@ fn test_bounded_uncommitted_entries_growth_with_partition() {
     raw_node.campaign().unwrap();
     loop {
         let rd = raw_node.ready();
+        s.wl().set_hardstate(rd.hs().unwrap().clone());
+        s.wl().append(rd.entries()).unwrap();
         if rd
             .ss()
             .map_or(false, |ss| ss.leader_id == raw_node.raft.leader_id)
@@ -1460,8 +1462,93 @@ fn test_async_ready_become_leader() {
     }
     assert_eq!(count, 4);
 
+    s.wl().append(rd.entries()).unwrap();
+
     let light_rd = raw_node.advance_append(rd);
     assert_eq!(light_rd.commit_index(), None);
     assert!(light_rd.committed_entries().is_empty());
     assert!(light_rd.messages().is_empty());
+    println!("{}", raw_node.raft.raft_log.persisted);
+}
+
+#[test]
+fn test_async_ready_multiple_snapshot() {
+    let l = default_logger();
+    let s = new_storage();
+    s.wl()
+        .apply_snapshot(new_snapshot(1, 1, vec![1, 2]))
+        .unwrap();
+
+    let mut raw_node = new_raw_node(1, vec![1, 2], 10, 1, s.clone(), &l);
+
+    let snapshot = new_snapshot(10, 2, vec![1, 2]);
+    let mut snapshot_msg = new_message(2, 1, MessageType::MsgSnapshot, 0);
+    snapshot_msg.set_term(2);
+    snapshot_msg.set_snapshot(snapshot.clone());
+    raw_node.step(snapshot_msg).unwrap();
+
+    let mut entries = vec![];
+    for i in 11..14 {
+        entries.push(new_entry(2, i, Some("hello")));
+    }
+    let mut append_msg = new_message_with_entries(2, 1, MessageType::MsgAppend, entries.to_vec());
+    append_msg.set_term(2);
+    append_msg.set_index(10);
+    append_msg.set_log_term(2);
+    append_msg.set_commit(12);
+    raw_node.step(append_msg).unwrap();
+
+    let rd = raw_node.ready();
+    assert_eq!(rd.number(), 1);
+    // If there is a snapshot, the committed entries should be empty.
+    must_cmp_ready(
+        &rd,
+        &Some(soft_state(2, StateRole::Follower)),
+        &Some(hard_state(2, 12, 0)),
+        &entries,
+        &[],
+        &Some(snapshot),
+        true,
+        true,
+    );
+    s.wl().set_hardstate(rd.hs().unwrap().clone());
+    s.wl().apply_snapshot(rd.snapshot().clone()).unwrap();
+    s.wl().append(rd.entries()).unwrap();
+
+    raw_node.advance_append_async(rd);
+
+    let snapshot = new_snapshot(20, 1, vec![1, 2]);
+    let mut snapshot_msg = new_message(2, 1, MessageType::MsgSnapshot, 0);
+    snapshot_msg.set_term(2);
+    snapshot_msg.set_snapshot(snapshot.clone());
+    raw_node.step(snapshot_msg).unwrap();
+
+    raw_node.on_persist_ready(1);
+
+    assert_eq!(raw_node.raft.raft_log.persisted, 13);
+
+    raw_node.advance_apply_to(10);
+
+    let rd = raw_node.ready();
+    assert_eq!(rd.number(), 2);
+    must_cmp_ready(
+        &rd,
+        &None,
+        &Some(hard_state(2, 20, 0)),
+        &[],
+        &[],
+        &Some(snapshot),
+        // the msg from ready 1
+        false,
+        true,
+    );
+    s.wl().set_hardstate(rd.hs().unwrap().clone());
+    s.wl().apply_snapshot(rd.snapshot().clone()).unwrap();
+
+    let light_rd = raw_node.advance_append(rd);
+    assert_eq!(light_rd.commit_index(), None);
+    assert!(light_rd.committed_entries().is_empty());
+    assert!(!light_rd.messages().is_empty());
+
+    raw_node.advance_apply_to(20);
 }

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -1468,7 +1468,6 @@ fn test_async_ready_become_leader() {
     assert_eq!(light_rd.commit_index(), None);
     assert!(light_rd.committed_entries().is_empty());
     assert!(light_rd.messages().is_empty());
-    println!("{}", raw_node.raft.raft_log.persisted);
 }
 
 #[test]

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -468,7 +468,7 @@ fn test_raw_node_propose_add_duplicate_node() {
     raw_node.campaign().expect("");
     loop {
         let rd = raw_node.ready();
-        s.wl().append(rd.entries()).unwrap();
+        s.wl().append(rd.entries()).expect("");
         if rd.ss().map_or(false, |ss| ss.leader_id == raw_node.raft.id) {
             let _ = raw_node.advance(rd);
             break;
@@ -530,7 +530,7 @@ fn test_raw_node_propose_add_learner_node() -> Result<()> {
     raw_node.campaign().expect("");
     loop {
         let rd = raw_node.ready();
-        s.wl().append(rd.entries()).unwrap();
+        s.wl().append(rd.entries()).expect("");
         if rd.ss().map_or(false, |ss| ss.leader_id == raw_node.raft.id) {
             let _ = raw_node.advance(rd);
             break;
@@ -580,7 +580,7 @@ fn test_raw_node_read_index() {
     raw_node.campaign().expect("");
     loop {
         let rd = raw_node.ready();
-        s.wl().append(rd.entries()).unwrap();
+        s.wl().append(rd.entries()).expect("");
         if rd.ss().map_or(false, |ss| ss.leader_id == raw_node.raft.id) {
             let _ = raw_node.advance(rd);
 

--- a/src/log_unstable.rs
+++ b/src/log_unstable.rs
@@ -87,16 +87,23 @@ impl Unstable {
 
     /// Clears the unstable entries and moves the stable offset up to the
     /// last index, if there is any.
-    pub fn stable_entries(&mut self) {
+    pub fn stable_entries(&mut self, index: u64, term: u64) {
+        // The snapshot must be stabled before entries
+        assert!(self.snapshot.is_none());
         if let Some(entry) = self.entries.last() {
+            assert_eq!(entry.get_index(), index);
+            assert_eq!(entry.get_term(), term);
             self.offset = entry.get_index() + 1;
             self.entries.clear();
         }
     }
 
     /// Clears the unstable snapshot.
-    pub fn stable_snap(&mut self) {
-        self.snapshot = None;
+    pub fn stable_snap(&mut self, index: u64) {
+        if let Some(snap) = &self.snapshot {
+            assert_eq!(snap.get_metadata().index, index);
+            self.snapshot = None;
+        }
     }
 
     /// From a given snapshot, restores the snapshot to self, but doesn't unpack.
@@ -319,7 +326,7 @@ mod test {
     }
 
     #[test]
-    fn test_stable_entries() {
+    fn test_stable_snapshot_and_entries() {
         let ents = vec![new_entry(5, 1), new_entry(5, 2), new_entry(6, 3)];
         let mut u = Unstable {
             entries: ents.clone(),
@@ -328,7 +335,8 @@ mod test {
             logger: crate::default_logger(),
         };
         assert_eq!(ents, u.entries);
-        u.stable_entries();
+        u.stable_snap(4);
+        u.stable_entries(6, 3);
         assert!(u.entries.is_empty());
         assert_eq!(u.offset, 7);
     }

--- a/src/log_unstable.rs
+++ b/src/log_unstable.rs
@@ -91,18 +91,46 @@ impl Unstable {
         // The snapshot must be stabled before entries
         assert!(self.snapshot.is_none());
         if let Some(entry) = self.entries.last() {
-            assert_eq!(entry.get_index(), index);
-            assert_eq!(entry.get_term(), term);
+            if entry.get_index() != index || entry.get_term() != term {
+                fatal!(
+                    self.logger,
+                    "the last one of unstable.slice has different index {} and term {}, expect {} {}",
+                    entry.get_index(),
+                    entry.get_term(),
+                    index,
+                    term
+                );
+            }
             self.offset = entry.get_index() + 1;
             self.entries.clear();
+        } else {
+            fatal!(
+                self.logger,
+                "unstable.slice is empty, expect its last one's index and term are {} and {}",
+                index,
+                term
+            );
         }
     }
 
     /// Clears the unstable snapshot.
     pub fn stable_snap(&mut self, index: u64) {
         if let Some(snap) = &self.snapshot {
-            assert_eq!(snap.get_metadata().index, index);
+            if snap.get_metadata().index != index {
+                fatal!(
+                    self.logger,
+                    "unstable.snap has different index {}, expect {}",
+                    snap.get_metadata().index,
+                    index
+                );
+            }
             self.snapshot = None;
+        } else {
+            fatal!(
+                self.logger,
+                "unstable.snap is none, expect a snapshot with index {}",
+                index
+            );
         }
     }
 

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -971,7 +971,7 @@ impl<T: Storage> Raft<T> {
         true
     }
 
-    /// Notifies that these raft logs or snapshot have been persisted.
+    /// Notifies that these raft logs have been persisted.
     pub fn on_persist_entries(&mut self, index: u64, term: u64) {
         let update = self.raft_log.maybe_persist(index, term);
         if update && self.state == StateRole::Leader {
@@ -994,6 +994,11 @@ impl<T: Storage> Raft<T> {
                 self.bcast_append();
             }
         }
+    }
+
+    /// Notifies that the snapshot have been persisted.
+    pub fn on_persist_snap(&mut self, index: u64) {
+        let _ = self.raft_log.maybe_persist_snap(index);
     }
 
     /// Returns true to indicate that there will probably be some readiness need to be handled.

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -998,7 +998,7 @@ impl<T: Storage> Raft<T> {
 
     /// Notifies that the snapshot have been persisted.
     pub fn on_persist_snap(&mut self, index: u64) {
-        let _ = self.raft_log.maybe_persist_snap(index);
+        self.raft_log.maybe_persist_snap(index);
     }
 
     /// Returns true to indicate that there will probably be some readiness need to be handled.

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -474,15 +474,9 @@ impl<T: Storage> RaftLog<T> {
         // We solve this problem by not forwarding the persisted index. It's pretty intuitive
         // because the first_update_index means there are snapshot or some entries whose indexes
         // are greater than or equal to the first_update_index have not been persisted yet.
-        let first_update_index = if let Some(index) = self
-            .unstable
-            .snapshot
-            .as_ref()
-            .map(|snap| snap.get_metadata().index)
-        {
-            index
-        } else {
-            self.unstable.offset
+        let first_update_index = match &self.unstable.snapshot {
+            Some(s) => s.get_metadata().index,
+            None => self.unstable.offset,
         };
         if index > self.persisted
             && index < first_update_index

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -463,7 +463,7 @@ impl<T: Storage> RaftLog<T> {
         // It's possible that the term check can be passed but index is greater
         // than or equal to the first_update_index in some corner cases.
         // We handle these issues by not forwarding the persisted index. It's pretty intuitive
-        // because the first_update_index means there are snapshot or some entries whose index
+        // because the first_update_index means there are snapshot or some entries whose indexes
         // are greater than or equal to the first_update_index have not been persisted yet.
         let first_update_index = if let Some(index) = self
             .unstable
@@ -499,7 +499,7 @@ impl<T: Storage> RaftLog<T> {
                     self.committed,
                 )
             }
-            // All of the index of latter entries must be greater than snapshot's index
+            // All of the indexes of later entries must be greater than snapshot's index
             if index >= self.unstable.offset {
                 fatal!(
                     self.unstable.logger,

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -542,11 +542,11 @@ impl<T: Storage> RawNode<T> {
         let rd_record = self.records.back().unwrap();
         assert!(rd_record.number == rd.number);
         let raft = &mut self.raft;
-        if rd_record.snapshot.is_some() {
-            raft.raft_log.stable_snap();
+        if let Some((index, _)) = rd_record.snapshot {
+            raft.raft_log.stable_snap(index);
         }
-        if rd_record.last_entry.is_some() {
-            raft.raft_log.stable_entries();
+        if let Some((index, term)) = rd_record.last_entry {
+            raft.raft_log.stable_entries(index, term);
         }
     }
 


### PR DESCRIPTION
Signed-off-by: gengliqi <gengliqiii@gmail.com>

This PR fixes a bug introduced by https://github.com/tikv/raft-rs/pull/410.
Consider the case below
1. A receives a snapshot with index 10
2. A gets a ready and handles it asynchronously
3. A receives a new snapshot with index 20
4. A calls on_persist_ready for ready 1
In step 4, the persisted index can not be updated to 10 because the first_index has changed to 21 so the term check can not be passed. (details in `RaftLog::term`)
I add a `maybe_persist_snap` function to fix this problem. The snapshot does not need to check the term because its data must be committed before and can not be changed in future.