### PR TITLE
*: introduce judge_split_prevote

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,10 @@ pub struct Config {
     /// rejoins the cluster.
     pub pre_vote: bool,
 
+    /// If split vote happens, only vote for the large id. This can save a round of campaign
+    /// when combined with `pre_vote`.
+    pub judge_split_prevote: bool,
+
     /// The range of election timeout. In some cases, we hope some nodes has less possibility
     /// to become leader. This configuration ensures that the randomized election_timeout
     /// will always be suit in [min_election_tick, max_election_tick).
@@ -109,6 +113,7 @@ impl Default for Config {
             max_inflight_msgs: 256,
             check_quorum: false,
             pre_vote: false,
+            judge_split_prevote: false,
             min_election_tick: 0,
             max_election_tick: 0,
             read_only_option: ReadOnlyOption::Safe,

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp;
+use std::cmp::{self, Ordering};
 
 use crate::eraftpb::{Entry, Snapshot};
 use crate::errors::{Error, Result, StorageError};
@@ -369,8 +369,8 @@ impl<T: Storage> RaftLog<T> {
     /// later term is more up-to-date. If the logs end with the same term, then
     /// whichever log has the larger last_index is more up-to-date. If the logs are
     /// the same, the given log is up-to-date.
-    pub fn is_up_to_date(&self, last_index: u64, term: u64) -> bool {
-        term > self.last_term() || (term == self.last_term() && last_index >= self.last_index())
+    pub fn is_up_to_date(&self, last_index: u64, term: u64) -> Ordering {
+        (term, last_index).cmp(&(self.last_term(), self.last_index()))
     }
 
     /// Returns committed and persisted entries since max(`since_idx` + 1, first_index).
@@ -567,7 +567,7 @@ impl<T: Storage> RaftLog<T> {
 #[cfg(test)]
 mod test {
     use std::{
-        cmp,
+        cmp::{self, Ordering},
         panic::{self, AssertUnwindSafe},
     };
 
@@ -660,22 +660,25 @@ mod test {
         raft_log.append(&previous_ents);
         let tests = vec![
             // greater term, ignore lastIndex
-            (raft_log.last_index() - 1, 4, true),
-            (raft_log.last_index(), 4, true),
-            (raft_log.last_index() + 1, 4, true),
+            (raft_log.last_index() - 1, 4, Ordering::Greater),
+            (raft_log.last_index(), 4, Ordering::Greater),
+            (raft_log.last_index() + 1, 4, Ordering::Greater),
             // smaller term, ignore lastIndex
-            (raft_log.last_index() - 1, 2, false),
-            (raft_log.last_index(), 2, false),
-            (raft_log.last_index() + 1, 2, false),
+            (raft_log.last_index() - 1, 2, Ordering::Less),
+            (raft_log.last_index(), 2, Ordering::Less),
+            (raft_log.last_index() + 1, 2, Ordering::Less),
             // equal term, lager lastIndex wins
-            (raft_log.last_index() - 1, 3, false),
-            (raft_log.last_index(), 3, true),
-            (raft_log.last_index() + 1, 3, true),
+            (raft_log.last_index() - 1, 3, Ordering::Less),
+            (raft_log.last_index(), 3, Ordering::Equal),
+            (raft_log.last_index() + 1, 3, Ordering::Greater),
         ];
         for (i, &(last_index, term, up_to_date)) in tests.iter().enumerate() {
             let g_up_to_date = raft_log.is_up_to_date(last_index, term);
             if g_up_to_date != up_to_date {
-                panic!("#{}: uptodate = {}, want {}", i, g_up_to_date, up_to_date);
+                panic!(
+                    "#{}: uptodate = {:?}, want {:?}",
+                    i, g_up_to_date, up_to_date
+                );
             }
         }
     }


### PR DESCRIPTION
During split prevote, a campaign will fail because all nodes think
it will collect enough votes, so after they actually start campaign,
no one votes for the other, the campaign has to fail.

`judge_split_prevote` solves the problem by adding extra constraint
to split prevote: only vote for nodes that have greater IDs. It's easy
to conclude that it works for peer numbers not greater 5. For 7 nodes,
it's still possible to split again. But it should be enough for most
cases. Because the constraint is only added for split prevote, so even
failure won't lead to worse result.

