### PR TITLE
Fix some typos in code and comments

### DIFF
--- a/datadriven/src/lib.rs
+++ b/datadriven/src/lib.rs
@@ -40,7 +40,7 @@ The path tree looks like the following:
             └── data_002.txt
 ```
 
-The comparision is done by [difference](https://docs.rs/difference/2.0.0/difference/)
+The comparison is done by [difference](https://docs.rs/difference/2.0.0/difference/)
 
 The difference between [cockroachdb/datadriven](https://github.com/cockroachdb/datadriven)
 1. no rewrite

--- a/harness/src/interface.rs
+++ b/harness/src/interface.rs
@@ -17,7 +17,7 @@
 use raft::{eraftpb::Message, storage::MemStorage, Raft, Result};
 use std::ops::{Deref, DerefMut};
 
-/// A simulated Raft façade for testing.
+/// A simulated Raft facade for testing.
 ///
 /// If the contained value is a `Some` operations happen. If they are a `None` operations are
 /// a no-op.

--- a/harness/src/network.rs
+++ b/harness/src/network.rs
@@ -27,7 +27,7 @@ use super::interface::Interface;
 
 /// A connection from one node to another.
 ///
-/// Used in by `Network` for determnining drop rates on messages.
+/// Used in by `Network` for determining drop rates on messages.
 #[derive(Default, Debug, PartialEq, Eq, Hash)]
 struct Connection {
     from: u64,
@@ -65,7 +65,7 @@ impl Network {
 
     /// Initializes a network from `peers`.
     ///
-    /// Nodes will recieve their ID based on their index in the vector, starting with 1.
+    /// Nodes will receive their ID based on their index in the vector, starting with 1.
     ///
     /// A `None` node will be replaced with a new Raft node, and its configuration will
     /// be `peers`.

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -3802,7 +3802,7 @@ pub fn new_test_learner_raft_with_prevote(
     new_test_raft_with_config(&cfg, storage, logger)
 }
 
-// TestLearnerElectionTimeout verfies that the leader should not start election
+// TestLearnerElectionTimeout verifies that the leader should not start election
 // even when times out.
 #[test]
 fn test_learner_election_timeout() {
@@ -3993,7 +3993,7 @@ fn test_restore_with_voters_outgoing() {
     assert!(!sm.restore(s));
 }
 
-// Verfies that a voter can be depromoted by snapshot.
+// Verifies that a voter can be depromoted by snapshot.
 #[test]
 fn test_restore_depromote_voter() {
     let l = default_logger();
@@ -4976,7 +4976,7 @@ fn test_request_snapshot_matched_change() {
         ProgressState::Replicate
     );
 
-    // Heartbeat is responsed with a request snapshot message.
+    // Heartbeat is responded with a request snapshot message.
     for _ in 0..nt.peers[&1].heartbeat_timeout() {
         nt.peers.get_mut(&1).unwrap().tick();
     }
@@ -5443,7 +5443,7 @@ fn test_uncommitted_entries_size_limit() {
     let result = nt.dispatch(vec![empty_msg].to_vec());
     assert!(result.is_ok());
 
-    // after reduce, new proposal should be accecpted
+    // after reduce, new proposal should be accepted
     let mut entry = Entry::default();
     entry.data = data;
     entry.index = 3;

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,7 +92,7 @@ pub struct Config {
     /// The election priority of this node.
     pub priority: u64,
 
-    /// Specify maximum of uncommited entry size.
+    /// Specify maximum of uncommitted entry size.
     /// When this limit is reached, all proposals to append new log will be dropped
     pub max_uncommitted_size: u64,
 }

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -80,10 +80,10 @@ pub struct SoftState {
     pub raft_state: StateRole,
 }
 
-/// UncommittedState is used to keep track of imformation of uncommitted
+/// UncommittedState is used to keep track of information of uncommitted
 /// log entries on 'leader' node
 struct UncommittedState {
-    /// Specify maximum of uncommited entry size.
+    /// Specify maximum of uncommitted entry size.
     /// When this limit is reached, all proposals to append new log will be dropped
     max_uncommitted_size: usize,
 
@@ -1168,7 +1168,7 @@ impl<T: Storage> Raft<T> {
         // could be expensive.
         self.pending_conf_index = last_index;
 
-        // No need to check result becase append_entry never refuse entries
+        // No need to check result because append_entry never refuse entries
         // which size is zero
         if !self.append_entry(&mut [Entry::default()]) {
             panic!("appending an empty entry should never be dropped")
@@ -1924,7 +1924,7 @@ impl<T: Storage> Raft<T> {
                     return Ok(());
                 }
 
-                // thinking: use an interally defined context instead of the user given context.
+                // thinking: use an internally defined context instead of the user given context.
                 // We can express this in terms of the term and index instead of
                 // a user-supplied value.
                 // This would allow multiple reads to piggyback on the same message.

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -614,7 +614,7 @@ impl<T: Storage> RawNode<T> {
     /// Returns the LightReady that contains commit index, committed entries and messages.
     ///
     /// Since Ready must be persisted in order, calling this function implicitly means
-    /// all readys collected before have been persisted.
+    /// all ready collected before have been persisted.
     #[inline]
     pub fn advance_append(&mut self, rd: Ready) -> LightReady {
         self.commit_ready(rd);

--- a/src/tracker/state.rs
+++ b/src/tracker/state.rs
@@ -24,7 +24,7 @@ pub enum ProgressState {
     Probe,
     /// Whether it's replicating.
     Replicate,
-    /// Whethers it's a snapshot.
+    /// Whether it's a snapshot.
     Snapshot,
 }
 
@@ -39,7 +39,7 @@ impl Display for ProgressState {
         match self {
             ProgressState::Probe => write!(f, "StateProbe"),
             ProgressState::Replicate => write!(f, "StateReplicate"),
-            ProgressState::Snapshot => write!(f, "StateSnaphot"),
+            ProgressState::Snapshot => write!(f, "StateSnapshot"),
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -73,7 +73,7 @@ pub fn limit_size<T: PbMessage + Clone>(entries: &mut Vec<T>, max: Option<u64>) 
 }
 
 /// Check whether the entry is continuous to the message.
-/// i.e msg's next entry index should be equal to the first entries' index
+/// i.e msg's next entry index should be equal to the index of the first entry in `ents`
 pub fn is_continuous_ents(msg: &Message, ents: &[Entry]) -> bool {
     if !msg.entries.is_empty() && !ents.is_empty() {
         let expected_next_idx = msg.entries.last().unwrap().index + 1;

--- a/src/util.rs
+++ b/src/util.rs
@@ -73,7 +73,7 @@ pub fn limit_size<T: PbMessage + Clone>(entries: &mut Vec<T>, max: Option<u64>) 
 }
 
 /// Check whether the entry is continuous to the message.
-/// i.e msg's next entry index should be equal to the first entries's index
+/// i.e msg's next entry index should be equal to the first entries' index
 pub fn is_continuous_ents(msg: &Message, ents: &[Entry]) -> bool {
     if !msg.entries.is_empty() && !ents.is_empty() {
         let expected_next_idx = msg.entries.last().unwrap().index + 1;


### PR DESCRIPTION
Fix some typos while reading the lib.

One in `src/tracker/state.rs`, **ProgressState::Snapshot => write!** should be **StateSnapshot**.

```rust
impl Display for ProgressState {
    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
        match self {
            ProgressState::Probe => write!(f, "StateProbe"),
            ProgressState::Replicate => write!(f, "StateReplicate"),
            ProgressState::Snapshot => write!(f, "StateSnaphot"),
        }
    }
}
```

Others are some typos in comments.

