### PR TITLE
Clean up the use of macro_use and extern crate

### DIFF
--- a/datadriven/src/datadriven.rs
+++ b/datadriven/src/datadriven.rs
@@ -11,6 +11,10 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
 
+use difference::assert_diff;
+use lazy_static::lazy_static;
+use slog::debug;
+
 /// The main function to run tests
 ///
 /// You need to pass the path of `testdata` where store the test cases, and your function

--- a/datadriven/src/datadriven/datadriven_test.rs
+++ b/datadriven/src/datadriven/datadriven_test.rs
@@ -6,6 +6,9 @@ use std::cmp;
 use std::fs::{read_to_string, OpenOptions};
 use std::io::Write;
 
+use difference::assert_diff;
+use slog::debug;
+
 fn fibonacci(n: u32) -> u32 {
     match n {
         0 => 1,

--- a/datadriven/src/lib.rs
+++ b/datadriven/src/lib.rs
@@ -50,17 +50,6 @@ The difference between [cockroachdb/datadriven](https://github.com/cockroachdb/d
 
 #![deny(missing_docs)]
 
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate anyhow;
-#[macro_use(assert_diff)]
-extern crate difference;
-#[macro_use]
-extern crate slog;
-extern crate slog_async;
-extern crate slog_term;
-
 mod datadriven;
 mod line_sparser;
 mod test_data;
@@ -75,6 +64,8 @@ use slog::Drain;
 use std::fs::read_dir;
 use std::io;
 use std::path::PathBuf;
+
+use slog::o;
 
 #[allow(dead_code)]
 fn default_logger() -> slog::Logger {

--- a/datadriven/src/line_sparser.rs
+++ b/datadriven/src/line_sparser.rs
@@ -2,6 +2,10 @@ use crate::test_data::CmdArg;
 use anyhow::Result;
 use regex::Regex;
 
+use anyhow::{anyhow, bail};
+use lazy_static::lazy_static;
+use slog::debug;
+
 // Token
 // (1) argument (no value)
 // (2) argument= (empty value)

--- a/datadriven/src/test_data_reader.rs
+++ b/datadriven/src/test_data_reader.rs
@@ -1,9 +1,13 @@
-use crate::line_sparser::parse_line;
-use crate::test_data::TestData;
-use anyhow::Result;
 use std::iter::Enumerate;
 use std::path::{Path, PathBuf};
 use std::str::Lines;
+
+use crate::line_sparser::parse_line;
+use crate::test_data::TestData;
+use anyhow::Result;
+
+use anyhow::bail;
+use slog::debug;
 
 pub struct TestDataReader<'a> {
     source_name: PathBuf,

--- a/examples/five_mem_node/main.rs
+++ b/examples/five_mem_node/main.rs
@@ -4,9 +4,6 @@
 // same time. And reassignment can be optimized by compiler.
 #![allow(clippy::field_reassign_with_default)]
 
-#[macro_use]
-extern crate slog;
-
 use slog::Drain;
 use std::collections::{HashMap, VecDeque};
 use std::sync::mpsc::{self, Receiver, Sender, SyncSender, TryRecvError};
@@ -18,6 +15,8 @@ use protobuf::Message as PbMessage;
 use raft::storage::MemStorage;
 use raft::{prelude::*, StateRole};
 use regex::Regex;
+
+use slog::{error, info, o};
 
 fn main() {
     let decorator = slog_term::TermDecorator::new().build();

--- a/examples/single_mem_node/main.rs
+++ b/examples/single_mem_node/main.rs
@@ -1,8 +1,5 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-#[macro_use]
-extern crate slog;
-
 use slog::{Drain, Logger};
 use std::collections::HashMap;
 use std::sync::mpsc::{self, RecvTimeoutError};
@@ -12,6 +9,8 @@ use std::time::{Duration, Instant};
 use raft::eraftpb::ConfState;
 use raft::prelude::*;
 use raft::storage::MemStorage;
+
+use slog::{info, o};
 
 type ProposeCallback = Box<dyn Fn() + Send>;
 

--- a/harness/tests/tests.rs
+++ b/harness/tests/tests.rs
@@ -6,16 +6,12 @@
 // same time. And reassignment can be optimized by compiler.
 #![allow(clippy::field_reassign_with_default)]
 
-#[cfg(feature = "failpoints")]
-#[macro_use]
-extern crate lazy_static;
-
 /// Get the count of macro's arguments.
 ///
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate tikv;
+/// # use tikv::count_args;
 /// # fn main() {
 /// assert_eq!(count_args!(), 0);
 /// assert_eq!(count_args!(1), 1);
@@ -34,7 +30,7 @@ macro_rules! count_args {
 /// # Examples
 ///
 /// ```
-/// # #[macro_use] extern crate tikv;
+/// # use tikv::map;
 /// # fn main() {
 /// // empty map
 /// let m: tikv::util::collections::HashMap<u8, u8> = map!();

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,6 +3,8 @@
 // TODO: std::error::Error::description is deprecated now, resolve it later.
 #![allow(deprecated)]
 
+use quick_error::quick_error;
+
 quick_error! {
     /// The base error type for raft
     #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -453,17 +453,6 @@ before taking old, removed peers offline.
 // same time. And reassignment can be optimized by compiler.
 #![allow(clippy::field_reassign_with_default)]
 
-#[cfg(feature = "failpoints")]
-#[macro_use]
-extern crate fail;
-
-#[macro_use]
-extern crate getset;
-#[macro_use]
-extern crate quick_error;
-#[macro_use]
-extern crate slog;
-
 macro_rules! fatal {
     ($logger:expr, $msg:expr) => {{
         let owned_kv = ($logger).list();
@@ -496,24 +485,25 @@ pub mod storage;
 mod tracker;
 pub mod util;
 
-pub use self::confchange::{Changer, MapChange};
-pub use self::config::Config;
-pub use self::errors::{Error, Result, StorageError};
-pub use self::log_unstable::Unstable;
-pub use self::quorum::joint::Configuration as JointConfig;
-pub use self::quorum::majority::Configuration as MajorityConfig;
-pub use self::raft::{vote_resp_msg_type, Raft, SoftState, StateRole, INVALID_ID, INVALID_INDEX};
-pub use self::raft_log::{RaftLog, NO_LIMIT};
-pub use self::tracker::{Inflights, Progress, ProgressState, ProgressTracker};
-
-#[allow(deprecated)]
-pub use self::raw_node::is_empty_snap;
-pub use self::raw_node::{LightReady, Peer, RawNode, Ready, SnapshotStatus};
-pub use self::read_only::{ReadOnlyOption, ReadState};
-pub use self::status::Status;
-pub use self::storage::{RaftState, Storage};
-pub use self::util::majority;
+pub use crate::raft::{vote_resp_msg_type, Raft, SoftState, StateRole, INVALID_ID, INVALID_INDEX};
+pub use confchange::{Changer, MapChange};
+pub use config::Config;
+pub use errors::{Error, Result, StorageError};
+pub use log_unstable::Unstable;
+pub use quorum::joint::Configuration as JointConfig;
+pub use quorum::majority::Configuration as MajorityConfig;
+pub use raft_log::{RaftLog, NO_LIMIT};
 pub use raft_proto::eraftpb;
+#[allow(deprecated)]
+pub use raw_node::is_empty_snap;
+pub use raw_node::{LightReady, Peer, RawNode, Ready, SnapshotStatus};
+pub use read_only::{ReadOnlyOption, ReadState};
+pub use status::Status;
+pub use storage::{RaftState, Storage};
+pub use tracker::{Inflights, Progress, ProgressState, ProgressTracker};
+pub use util::majority;
+
+use slog::o;
 
 pub mod prelude {
     //! A "prelude" for crates using the `raft` crate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,8 +503,6 @@ pub use storage::{RaftState, Storage};
 pub use tracker::{Inflights, Progress, ProgressState, ProgressTracker};
 pub use util::majority;
 
-use slog::o;
-
 pub mod prelude {
     //! A "prelude" for crates using the `raft` crate.
     //!
@@ -539,7 +537,7 @@ pub mod prelude {
 /// Currently, this is a `log` adaptor behind a `Once` to ensure there is no clobbering.
 #[cfg(any(test, feature = "default-logger"))]
 pub fn default_logger() -> slog::Logger {
-    use slog::Drain;
+    use slog::{o, Drain};
     use std::sync::{Mutex, Once};
 
     static LOGGER_INITIALIZED: Once = Once::new();

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -26,6 +26,11 @@ use raft_proto::ConfChangeI;
 use rand::{self, Rng};
 use slog::{self, Logger};
 
+#[cfg(feature = "failpoints")]
+use fail::fail_point;
+use getset::Getters;
+use slog::{debug, error, info, o, trace, warn};
+
 use super::errors::{Error, Result, StorageError};
 use super::raft_log::RaftLog;
 use super::read_only::{ReadOnly, ReadOnlyOption, ReadState};

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -16,15 +16,16 @@
 
 use std::cmp;
 
+use slog::Logger;
+
 use crate::eraftpb::{Entry, Snapshot};
 use crate::errors::{Error, Result, StorageError};
 use crate::log_unstable::Unstable;
 use crate::storage::Storage;
 use crate::util;
-
-use slog::Logger;
-
 pub use crate::util::NO_LIMIT;
+
+use slog::{debug, info, trace};
 
 /// Raft log implementation
 pub struct RaftLog<T: Storage> {

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -24,13 +24,15 @@ use std::{collections::VecDeque, mem};
 
 use protobuf::Message as PbMessage;
 use raft_proto::ConfChangeI;
+use slog::Logger;
 
 use crate::eraftpb::{ConfState, Entry, EntryType, HardState, Message, MessageType, Snapshot};
 use crate::errors::{Error, Result};
 use crate::read_only::ReadState;
 use crate::{config::Config, StateRole};
 use crate::{Raft, SoftState, Status, Storage};
-use slog::Logger;
+
+use slog::info;
 
 /// Represents a Peer node in the cluster.
 #[derive(Debug, Default)]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -28,6 +28,8 @@ use crate::eraftpb::*;
 use crate::errors::{Error, Result, StorageError};
 use crate::util::limit_size;
 
+use getset::{Getters, Setters};
+
 /// Holds both the hard state (commit index, vote leader, term) and the configuration state
 /// (Current node IDs)
 #[derive(Debug, Clone, Default, Getters, Setters)]

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -30,6 +30,8 @@ use crate::quorum::{AckedIndexer, Index, VoteResult};
 use crate::{DefaultHashBuilder, HashMap, HashSet, JointConfig};
 use std::fmt::Debug;
 
+use getset::Getters;
+
 /// Config reflects the configuration tracked in a ProgressTracker.
 #[derive(Clone, Debug, Default, PartialEq, Getters)]
 pub struct Configuration {

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,14 +3,17 @@
 
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use slog::{OwnedKVList, Record, KV};
 use std::fmt;
 use std::fmt::Write;
 use std::u64;
 
+use slog::{OwnedKVList, Record, KV};
+
 use crate::eraftpb::{Entry, Message};
 use crate::HashSet;
 use protobuf::Message as PbMessage;
+
+use slog::{b, record_static};
 
 /// A number to represent that there is no limit.
 pub const NO_LIMIT: u64 = u64::MAX;


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

`macro_use` and `extern crate` are no longer needed in 99% of circumstances. So I clean up them to make sure it's more consistent, more flexible, and easier to look up the macro definition. You can check [Path clarity](https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html) for more detials.