### PR TITLE
implement committed entries pagination

### DIFF
--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -107,7 +107,7 @@ fn next_ents(r: &mut Raft<MemStorage>, s: &MemStorage) -> Vec<Entry> {
         s.wl().append(&unstable).expect("");
         r.on_persist_entries(last_idx, last_term);
     }
-    let ents = r.raft_log.next_entries();
+    let ents = r.raft_log.next_entries(None);
     r.commit_apply(r.raft_log.committed);
     ents.unwrap_or_else(Vec::new)
 }

--- a/harness/tests/integration_cases/test_raft_paper.rs
+++ b/harness/tests/integration_cases/test_raft_paper.rs
@@ -482,7 +482,7 @@ fn test_leader_commit_entry() {
 
     assert_eq!(r.raft_log.committed, li + 1);
     let wents = vec![new_entry(1, li + 1, SOME_DATA)];
-    assert_eq!(r.raft_log.next_entries(), Some(wents));
+    assert_eq!(r.raft_log.next_entries(None), Some(wents));
     let mut msgs = r.read_messages();
     msgs.sort_by_key(|m| format!("{:?}", m));
     for (i, m) in msgs.drain(..).enumerate() {
@@ -572,7 +572,7 @@ fn test_leader_commit_preceding_entries() {
             empty_entry(3, li + 1),
             new_entry(3, li + 2, SOME_DATA),
         ]);
-        let g = r.raft_log.next_entries();
+        let g = r.raft_log.next_entries(None);
         let wg = Some(tt);
         if g != wg {
             panic!("#{}: ents = {:?}, want {:?}", i, g, wg);
@@ -629,7 +629,7 @@ fn test_follower_commit_entry() {
             );
         }
         let wents = Some(ents[..commit as usize].to_vec());
-        let g = r.raft_log.next_entries();
+        let g = r.raft_log.next_entries(None);
         if g != wents {
             panic!("#{}: next_ents = {:?}, want {:?}", i, g, wents);
         }

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -1583,7 +1583,7 @@ fn test_async_ready_multiple_snapshot() {
 }
 
 #[test]
-fn test_ready_with_options() {
+fn test_committed_entries_size_limit() {
     let l = default_logger();
     let s = new_storage();
     s.wl()
@@ -1614,7 +1614,7 @@ fn test_ready_with_options() {
 
     // Advance the ready, and we can get committed_entries as expected.
     // Test using 0 as `committed_entries_max_size` works as expected.
-    raw_node.raft.max_size_per_committed_entries = 0;
+    raw_node.raft.max_committed_size_per_ready = 0;
     let rd = raw_node.advance(rd);
     // `MemStorage::entries` uses `util::limit_size` to limit size of committed entries.
     // So there will be at least one entry.
@@ -1622,7 +1622,7 @@ fn test_ready_with_options() {
 
     // Fetch a `Ready` again without size limit for committed entries.
     assert!(raw_node.has_ready());
-    raw_node.raft.max_size_per_committed_entries = u64::MAX;
+    raw_node.raft.max_committed_size_per_ready = u64::MAX;
     let rd = raw_node.ready();
     assert_eq!(rd.committed_entries().len(), 7);
 

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -65,8 +65,7 @@ fn new_raw_node(
     storage: MemStorage,
     logger: &Logger,
 ) -> RawNode<MemStorage> {
-    let mut config = new_test_config(id, election_tick, heartbeat_tick);
-    config.applied = storage.last_index().unwrap();
+    let config = new_test_config(id, election_tick, heartbeat_tick);
     new_raw_node_with_config(peers, &config, storage, logger)
 }
 

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -1614,14 +1614,15 @@ fn test_ready_with_options() {
 
     // Advance the ready, and we can get committed_entries as expected.
     // Test using 0 as `committed_entries_max_size` works as expected.
-    let opts = ReadyOptions::default().committed_entries_max_size(0);
-    let rd = raw_node.advance_with_options(rd, opts);
+    raw_node.raft.max_size_per_committed_entries = 0;
+    let rd = raw_node.advance(rd);
     // `MemStorage::entries` uses `util::limit_size` to limit size of committed entries.
     // So there will be at least one entry.
     assert_eq!(rd.committed_entries().len(), 1);
 
     // Fetch a `Ready` again without size limit for committed entries.
     assert!(raw_node.has_ready());
+    raw_node.raft.max_size_per_committed_entries = u64::MAX;
     let rd = raw_node.ready();
     assert_eq!(rd.committed_entries().len(), 7);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,6 +95,9 @@ pub struct Config {
     /// Specify maximum of uncommitted entry size.
     /// When this limit is reached, all proposals to append new log will be dropped
     pub max_uncommitted_size: u64,
+
+    /// Max size for committed entries in a `Ready`.
+    pub max_size_per_committed_entries: u64,
 }
 
 impl Default for Config {
@@ -116,6 +119,7 @@ impl Default for Config {
             batch_append: false,
             priority: 0,
             max_uncommitted_size: NO_LIMIT,
+            max_size_per_committed_entries: u64::MAX,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -97,7 +97,7 @@ pub struct Config {
     pub max_uncommitted_size: u64,
 
     /// Max size for committed entries in a `Ready`.
-    pub max_size_per_committed_entries: u64,
+    pub max_committed_size_per_ready: u64,
 }
 
 impl Default for Config {
@@ -119,7 +119,7 @@ impl Default for Config {
             batch_append: false,
             priority: 0,
             max_uncommitted_size: NO_LIMIT,
-            max_size_per_committed_entries: u64::MAX,
+            max_committed_size_per_ready: NO_LIMIT,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,7 +516,7 @@ pub use raft_log::{RaftLog, NO_LIMIT};
 pub use raft_proto::eraftpb;
 #[allow(deprecated)]
 pub use raw_node::is_empty_snap;
-pub use raw_node::{LightReady, Peer, RawNode, Ready, SnapshotStatus};
+pub use raw_node::{LightReady, Peer, RawNode, Ready, ReadyOptions, SnapshotStatus};
 pub use read_only::{ReadOnlyOption, ReadState};
 pub use status::Status;
 pub use storage::{RaftState, Storage};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,7 +516,7 @@ pub use raft_log::{RaftLog, NO_LIMIT};
 pub use raft_proto::eraftpb;
 #[allow(deprecated)]
 pub use raw_node::is_empty_snap;
-pub use raw_node::{LightReady, Peer, RawNode, Ready, ReadyOptions, SnapshotStatus};
+pub use raw_node::{LightReady, Peer, RawNode, Ready, SnapshotStatus};
 pub use read_only::{ReadOnlyOption, ReadState};
 pub use status::Status;
 pub use storage::{RaftState, Storage};

--- a/src/log_unstable.rs
+++ b/src/log_unstable.rs
@@ -150,20 +150,18 @@ impl Unstable {
         let after = ents[0].index;
         if after == self.offset + self.entries.len() as u64 {
             // after is the next index in the self.entries, append directly
-            self.entries.extend_from_slice(ents);
         } else if after <= self.offset {
             // The log is being truncated to before our current offset
             // portion, so set the offset and replace the entries
             self.offset = after;
             self.entries.clear();
-            self.entries.extend_from_slice(ents);
         } else {
             // truncate to after and copy to self.entries then append
             let off = self.offset;
             self.must_check_outofbounds(off, after);
             self.entries.truncate((after - off) as usize);
-            self.entries.extend_from_slice(ents);
         }
+        self.entries.extend_from_slice(ents);
     }
 
     /// Returns a slice of entries between the high and low.

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -259,7 +259,7 @@ pub struct RaftCore<T: Storage> {
     uncommitted_state: UncommittedState,
 
     /// Max size per committed entries in a `Read`.
-    pub max_committed_size_per_ready: u64,
+    pub(crate) max_committed_size_per_ready: u64,
 }
 
 /// A struct that represents the raft consensus itself. Stores details concerning the current
@@ -589,6 +589,11 @@ impl<T: Storage> Raft<T> {
         self.raft_log
             .term(self.raft_log.applied)
             .map_or(false, |t| t == self.term)
+    }
+
+    /// Set `max_committed_size_per_ready` to `size`.
+    pub fn set_max_committed_size_per_ready(&mut self, size: u64) {
+        self.max_committed_size_per_ready = size;
     }
 }
 

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -257,6 +257,9 @@ pub struct RaftCore<T: Storage> {
 
     /// Track uncommitted log entry on this node
     uncommitted_state: UncommittedState,
+
+    /// Max size per committed entries in a `Read`.
+    pub max_size_per_committed_entries: u64,
 }
 
 /// A struct that represents the raft consensus itself. Stores details concerning the current
@@ -361,6 +364,7 @@ impl<T: Storage> Raft<T> {
                     uncommitted_size: 0,
                     last_log_tail_index: 0,
                 },
+                max_size_per_committed_entries: c.max_size_per_committed_entries,
             },
         };
         confchange::restore(&mut r.prs, r.r.raft_log.last_index(), conf_state)?;

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -259,7 +259,7 @@ pub struct RaftCore<T: Storage> {
     uncommitted_state: UncommittedState,
 
     /// Max size per committed entries in a `Read`.
-    pub max_size_per_committed_entries: u64,
+    pub max_committed_size_per_ready: u64,
 }
 
 /// A struct that represents the raft consensus itself. Stores details concerning the current
@@ -364,7 +364,7 @@ impl<T: Storage> Raft<T> {
                     uncommitted_size: 0,
                     last_log_tail_index: 0,
                 },
-                max_size_per_committed_entries: c.max_size_per_committed_entries,
+                max_committed_size_per_ready: c.max_committed_size_per_ready,
             },
         };
         confchange::restore(&mut r.prs, r.r.raft_log.last_index(), conf_state)?;

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -413,7 +413,7 @@ impl<T: Storage> RawNode<T> {
     /// Generates a LightReady that has the committed entries and messages but no commit index.
     fn gen_light_ready(&mut self) -> LightReady {
         let mut rd = LightReady::default();
-        let max_size = Some(self.raft.max_size_per_committed_entries);
+        let max_size = Some(self.raft.max_committed_size_per_ready);
         let raft = &mut self.raft;
         rd.committed_entries = raft
             .raft_log

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -411,12 +411,13 @@ impl<T: Storage> RawNode<T> {
     }
 
     /// Generates a LightReady that has the committed entries and messages but no commit index.
-    fn gen_light_ready(&mut self, options: ReadyOptions) -> LightReady {
+    fn gen_light_ready(&mut self) -> LightReady {
         let mut rd = LightReady::default();
+        let max_size = Some(self.raft.max_size_per_committed_entries);
         let raft = &mut self.raft;
         rd.committed_entries = raft
             .raft_log
-            .next_entries_since(self.commit_since_index, options.committed_entries_max_size)
+            .next_entries_since(self.commit_since_index, max_size)
             .unwrap_or_default();
         // Update raft uncommitted entries size
         raft.reduce_uncommitted_size(&rd.committed_entries);
@@ -440,7 +441,7 @@ impl<T: Storage> RawNode<T> {
     /// `step`, `propose`, `campaign` to change internal state.
     ///
     /// `has_ready` should be called first to check if it's necessary to handle the ready.
-    pub fn ready_with_options(&mut self, options: ReadyOptions) -> Ready {
+    pub fn ready(&mut self) -> Ready {
         let raft = &mut self.raft;
 
         self.max_number += 1;
@@ -509,14 +510,9 @@ impl<T: Storage> RawNode<T> {
         // Leader can send messages immediately to make replication concurrently.
         // For more details, check raft thesis 10.2.1.
         rd.is_persisted_msg = raft.state != StateRole::Leader;
-        rd.light = self.gen_light_ready(options);
+        rd.light = self.gen_light_ready();
         self.records.push_back(rd_record);
         rd
-    }
-
-    /// Same as `ready_with_options(Default::default)`.
-    pub fn ready(&mut self) -> Ready {
-        self.ready_with_options(Default::default())
     }
 
     /// HasReady called when RawNode user need to check if any Ready pending.
@@ -620,16 +616,11 @@ impl<T: Storage> RawNode<T> {
     /// Returns the LightReady that contains commit index, committed entries and messages. `LightReady`
     /// contains updates that only valid after persisting last ready. It should also be fully processed.
     /// Then `advance_apply` or `advance_apply_to` should be used later to update applying progress.
-    pub fn advance_with_options(&mut self, rd: Ready, options: ReadyOptions) -> LightReady {
+    pub fn advance(&mut self, rd: Ready) -> LightReady {
         let applied = self.commit_since_index;
-        let light_rd = self.advance_append_with_options(rd, options);
+        let light_rd = self.advance_append(rd);
         self.advance_apply_to(applied);
         light_rd
-    }
-
-    /// Same as `advance_with_options(rd, Default::default())`.
-    pub fn advance(&mut self, rd: Ready) -> LightReady {
-        self.advance_with_options(rd, Default::default())
     }
 
     /// Advances the ready without applying committed entries. `advance_apply` or `advance_apply_to`
@@ -640,10 +631,10 @@ impl<T: Storage> RawNode<T> {
     /// Since Ready must be persisted in order, calling this function implicitly means
     /// all ready collected before have been persisted.
     #[inline]
-    pub fn advance_append_with_options(&mut self, rd: Ready, options: ReadyOptions) -> LightReady {
+    pub fn advance_append(&mut self, rd: Ready) -> LightReady {
         self.commit_ready(rd);
         self.on_persist_ready(self.max_number);
-        let mut light_rd = self.gen_light_ready(options);
+        let mut light_rd = self.gen_light_ready();
         if self.raft.state != StateRole::Leader && !light_rd.messages().is_empty() {
             fatal!(self.raft.logger, "not leader but has new msg after advance");
         }
@@ -658,11 +649,6 @@ impl<T: Storage> RawNode<T> {
         }
         assert_eq!(hard_state, self.prev_hs, "hard state != prev_hs");
         light_rd
-    }
-
-    /// Same as `advance_append_with_options(rd, Default::default())`.
-    pub fn advance_append(&mut self, rd: Ready) -> LightReady {
-        self.advance_append_with_options(rd, Default::default())
     }
 
     /// Same as `advance_append` except that it allows to only store the updates in cache. `on_persist_ready`
@@ -770,21 +756,6 @@ impl<T: Storage> RawNode<T> {
     #[inline]
     pub fn set_batch_append(&mut self, batch_append: bool) {
         self.raft.set_batch_append(batch_append)
-    }
-}
-
-/// Options for generting `Ready` or `LightReady`.
-#[derive(Clone, Copy, Default)]
-pub struct ReadyOptions {
-    /// Limit the memory usage for committed entries.
-    pub committed_entries_max_size: Option<u64>,
-}
-
-impl ReadyOptions {
-    /// Set `committed_entries_max_size` to the given value.
-    pub fn committed_entries_max_size(mut self, size: u64) -> Self {
-        self.committed_entries_max_size = Some(size);
-        self
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -62,6 +62,7 @@ pub fn limit_size<T: PbMessage + Clone>(entries: &mut Vec<T>, max: Option<u64>) 
     let limit = entries
         .iter()
         .take_while(|&e| {
+            #[allow(clippy::branches_sharing_code)]
             if size == 0 {
                 size += u64::from(e.compute_size());
                 true

--- a/src/util.rs
+++ b/src/util.rs
@@ -62,14 +62,12 @@ pub fn limit_size<T: PbMessage + Clone>(entries: &mut Vec<T>, max: Option<u64>) 
     let limit = entries
         .iter()
         .take_while(|&e| {
-            #[allow(clippy::branches_sharing_code)]
             if size == 0 {
                 size += u64::from(e.compute_size());
-                true
-            } else {
-                size += u64::from(e.compute_size());
-                size <= max
+                return true;
             }
+            size += u64::from(e.compute_size());
+            size <= max
         })
         .count();
 


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

This is a re-implement for #356, except such things:
* the new configuration `max_committed_size_per_ready` isn't pushed into `RaftLog`
* new test cases are simplified into one, and it covers `Ready` and `LightReady`