### PR TITLE
introduce elastic inflight to save memory

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -20,6 +20,8 @@ fn main() {
     suites::bench_raft(&mut c);
     suites::bench_raw_node(&mut c);
     suites::bench_progress(&mut c);
+    suites::bench_inflights_256(&mut c);
+    suites::bench_inflights_4096(&mut c);
 
     c.final_summary();
 }

--- a/benches/suites/progress.rs
+++ b/benches/suites/progress.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use criterion::{Bencher, Criterion};
+use raft::Inflights;
 use raft::Progress;
 
 pub fn bench_progress(c: &mut Criterion) {
@@ -9,9 +10,27 @@ pub fn bench_progress(c: &mut Criterion) {
 
 pub fn bench_progress_default(c: &mut Criterion) {
     let bench = |b: &mut Bencher| {
-        // No setup.
         b.iter(|| Progress::new(9, 10));
     };
 
     c.bench_function("Progress::default", bench);
+}
+
+pub fn bench_inflights_256(c: &mut Criterion) {
+    bench_inflights(c, 256);
+}
+
+pub fn bench_inflights_4096(c: &mut Criterion) {
+    bench_inflights(c, 4096);
+}
+
+fn bench_inflights(c: &mut Criterion, capacity: usize) {
+    let mut inflights = Inflights::new(capacity);
+    let bench = |b: &mut Bencher| {
+        b.iter(|| {
+            (0..capacity).for_each(|i| inflights.add(i as u64 + 1));
+            (0..capacity).for_each(|_| inflights.free_first_one());
+        })
+    };
+    c.bench_function(&format!("Inflights({})", capacity), bench);
 }

--- a/datadriven/src/test_data.rs
+++ b/datadriven/src/test_data.rs
@@ -89,7 +89,7 @@ mod tests {
             vals: vec!["some string".to_string()],
         };
         d.cmd_args.push(cmd_arg);
-        assert_eq!(d.contains_key("key2"), true);
-        assert_eq!(d.contains_key("key1"), false);
+        assert!(d.contains_key("key2"));
+        assert!(!d.contains_key("key1"));
     }
 }

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -2369,9 +2369,8 @@ fn test_read_only_with_learner() {
             .read_states
             .drain(..)
             .collect();
-        assert_eq!(
-            read_states.is_empty(),
-            false,
+        assert!(
+            !read_states.is_empty(),
             "#{}: read_states is empty, want non-empty",
             i
         );

--- a/src/confchange/datadriven_test.rs
+++ b/src/confchange/datadriven_test.rs
@@ -8,7 +8,7 @@ fn test_conf_change_data_driven() -> anyhow::Result<()> {
     walk("src/confchange/testdata", |path| -> anyhow::Result<()> {
         let logger = default_logger();
 
-        let mut tr = ProgressTracker::new(10, default_logger());
+        let mut tr = ProgressTracker::new(10);
         let mut idx = 0;
 
         run_test(

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -324,12 +324,7 @@ impl<T: Storage> Raft<T> {
         let learners = &conf_state.learners;
 
         let mut r = Raft {
-            prs: ProgressTracker::with_capacity(
-                voters.len(),
-                learners.len(),
-                c.max_inflight_msgs,
-                logger.clone(),
-            ),
+            prs: ProgressTracker::with_capacity(voters.len(), learners.len(), c.max_inflight_msgs),
             msgs: Default::default(),
             r: RaftCore {
                 id: c.id,

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -22,8 +22,6 @@ pub use self::inflights::Inflights;
 pub use self::progress::Progress;
 pub use self::state::ProgressState;
 
-use slog::Logger;
-
 use crate::confchange::{MapChange, MapChangeType};
 use crate::eraftpb::ConfState;
 use crate::quorum::{AckedIndexer, Index, VoteResult};
@@ -191,7 +189,7 @@ impl AckedIndexer for ProgressMap {
 
 /// `ProgressTracker` contains several `Progress`es,
 /// which could be `Leader`, `Follower` and `Learner`.
-#[derive(Clone, Getters)]
+#[derive(Getters)]
 pub struct ProgressTracker {
     progress: ProgressMap,
 
@@ -205,22 +203,16 @@ pub struct ProgressTracker {
     max_inflight: usize,
 
     group_commit: bool,
-    pub(crate) logger: Logger,
 }
 
 impl ProgressTracker {
     /// Creates a new ProgressTracker.
-    pub fn new(max_inflight: usize, logger: Logger) -> Self {
-        Self::with_capacity(0, 0, max_inflight, logger)
+    pub fn new(max_inflight: usize) -> Self {
+        Self::with_capacity(0, 0, max_inflight)
     }
 
     /// Create a progress set with the specified sizes already reserved.
-    pub fn with_capacity(
-        voters: usize,
-        learners: usize,
-        max_inflight: usize,
-        logger: Logger,
-    ) -> Self {
+    pub fn with_capacity(voters: usize, learners: usize, max_inflight: usize) -> Self {
         ProgressTracker {
             progress: HashMap::with_capacity_and_hasher(
                 voters + learners,
@@ -230,7 +222,6 @@ impl ProgressTracker {
             votes: HashMap::with_capacity_and_hasher(voters, DefaultHashBuilder::default()),
             max_inflight,
             group_commit: false,
-            logger,
         }
     }
 

--- a/src/tracker/progress.rs
+++ b/src/tracker/progress.rs
@@ -4,7 +4,7 @@ use crate::{Inflights, ProgressState, INVALID_INDEX};
 use std::cmp;
 
 /// The progress of catching up from a restart.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Progress {
     /// How much state is matched.
     pub matched: u64,
@@ -87,7 +87,6 @@ impl Progress {
         self.pending_snapshot = 0;
         self.pending_request_snapshot = INVALID_INDEX;
         self.recent_active = false;
-        debug_assert!(self.ins.cap() != 0);
         self.ins.reset();
     }
 


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

Like #423 this PR also want to resolve #419 , but use another solution that lazy allocating inflight buffers and shrink it if necessary. No new APIs are introduced.

Would you mind to take a look? @jayzhan211 