### PR TITLE
Support fetch raft entry in async way

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raft"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
 keywords = ["raft", "distributed-systems", "ha"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raft"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
 keywords = ["raft", "distributed-systems", "ha"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ fail = { version = "0.4", optional = true }
 getset = "0.1.1"
 protobuf = "2"
 thiserror = "1.0"
-raft-proto = { path = "proto", version = "0.6.0", default-features = false }
+raft-proto = { path = "proto", version = "0.7.0", default-features = false }
 rand = "0.8"
 slog = "2.2"
 slog-envlogger = { version = "2.1.0", optional = true }

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -3048,7 +3048,7 @@ fn test_slow_node_restore() {
     for _ in 0..100 {
         nt.send(vec![new_message(1, 1, MessageType::MsgPropose, 1)]);
     }
-    next_ents(&mut nt.peers.get_mut(&1).unwrap(), &nt.storage[&1]);
+    next_ents(nt.peers.get_mut(&1).unwrap(), &nt.storage[&1]);
     nt.storage[&1]
         .wl()
         .commit_to(nt.peers[&1].raft_log.applied)
@@ -3450,7 +3450,7 @@ fn test_leader_transfer_after_snapshot() {
     nt.isolate(3);
 
     nt.send(vec![new_message(1, 1, MessageType::MsgPropose, 1)]);
-    next_ents(&mut nt.peers.get_mut(&1).unwrap(), &nt.storage[&1]);
+    next_ents(nt.peers.get_mut(&1).unwrap(), &nt.storage[&1]);
     nt.storage[&1]
         .wl()
         .commit_to(nt.peers[&1].raft_log.applied)

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -2841,7 +2841,7 @@ fn test_send_append_for_progress_probe() {
             // loop. After that, the follower is paused until a heartbeat response is
             // received.
             let _ = r.append_entry(&mut [new_entry(0, 0, SOME_DATA)]);
-            r.send_append(2, false);
+            r.send_append(2);
             let msg = r.read_messages();
             assert_eq!(msg.len(), 1);
             assert_eq!(msg[0].index, 0);
@@ -2850,7 +2850,7 @@ fn test_send_append_for_progress_probe() {
         assert!(r.prs().get(2).unwrap().paused);
         for _ in 0..10 {
             let _ = r.append_entry(&mut [new_entry(0, 0, SOME_DATA)]);
-            r.send_append(2, false);
+            r.send_append(2);
             assert_eq!(r.read_messages().len(), 0);
         }
 
@@ -2887,7 +2887,7 @@ fn test_send_append_for_progress_replicate() {
 
     for _ in 0..10 {
         let _ = r.append_entry(&mut [new_entry(0, 0, SOME_DATA)]);
-        r.send_append(2, false);
+        r.send_append(2);
         assert_eq!(r.read_messages().len(), 1);
     }
 }
@@ -2903,7 +2903,7 @@ fn test_send_append_for_progress_snapshot() {
 
     for _ in 0..10 {
         let _ = r.append_entry(&mut [new_entry(0, 0, SOME_DATA)]);
-        r.send_append(2, false);
+        r.send_append(2);
         assert_eq!(r.read_messages().len(), 0);
     }
 }

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -2841,7 +2841,7 @@ fn test_send_append_for_progress_probe() {
             // loop. After that, the follower is paused until a heartbeat response is
             // received.
             let _ = r.append_entry(&mut [new_entry(0, 0, SOME_DATA)]);
-            r.send_append(2);
+            r.send_append(2, false);
             let msg = r.read_messages();
             assert_eq!(msg.len(), 1);
             assert_eq!(msg[0].index, 0);
@@ -2850,7 +2850,7 @@ fn test_send_append_for_progress_probe() {
         assert!(r.prs().get(2).unwrap().paused);
         for _ in 0..10 {
             let _ = r.append_entry(&mut [new_entry(0, 0, SOME_DATA)]);
-            r.send_append(2);
+            r.send_append(2, false);
             assert_eq!(r.read_messages().len(), 0);
         }
 
@@ -2887,7 +2887,7 @@ fn test_send_append_for_progress_replicate() {
 
     for _ in 0..10 {
         let _ = r.append_entry(&mut [new_entry(0, 0, SOME_DATA)]);
-        r.send_append(2);
+        r.send_append(2, false);
         assert_eq!(r.read_messages().len(), 1);
     }
 }
@@ -2903,7 +2903,7 @@ fn test_send_append_for_progress_snapshot() {
 
     for _ in 0..10 {
         let _ = r.append_entry(&mut [new_entry(0, 0, SOME_DATA)]);
-        r.send_append(2);
+        r.send_append(2, false);
         assert_eq!(r.read_messages().len(), 0);
     }
 }

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -3121,7 +3121,7 @@ fn test_step_ignore_config() {
     let mut we = empty_entry(1, 3);
     we.set_entry_type(EntryType::EntryNormal);
     let wents = vec![we];
-    let entries = r.raft_log.entries(index + 1, None).expect("");
+    let entries = r.raft_log.entries(index + 1, None, None).expect("");
     assert_eq!(entries, wents);
     assert_eq!(r.pending_conf_index, pending_conf_index);
 }

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -3123,7 +3123,7 @@ fn test_step_ignore_config() {
     let wents = vec![we];
     let entries = r
         .raft_log
-        .entries(index + 1, None, GetEntriesContext::test())
+        .entries(index + 1, None, GetEntriesContext::none())
         .expect("");
     assert_eq!(entries, wents);
     assert_eq!(r.pending_conf_index, pending_conf_index);

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -3123,7 +3123,7 @@ fn test_step_ignore_config() {
     let wents = vec![we];
     let entries = r
         .raft_log
-        .entries(index + 1, None, GetEntriesContext::Test)
+        .entries(index + 1, None, GetEntriesContext::test())
         .expect("");
     assert_eq!(entries, wents);
     assert_eq!(r.pending_conf_index, pending_conf_index);

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -3123,7 +3123,7 @@ fn test_step_ignore_config() {
     let wents = vec![we];
     let entries = r
         .raft_log
-        .entries(index + 1, None, GetEntriesContext::none())
+        .entries(index + 1, None, GetEntriesContext::empty(false))
         .expect("");
     assert_eq!(entries, wents);
     assert_eq!(r.pending_conf_index, pending_conf_index);

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -21,7 +21,7 @@ use std::panic::{self, AssertUnwindSafe};
 use harness::*;
 use protobuf::Message as PbMessage;
 use raft::eraftpb::*;
-use raft::storage::MemStorage;
+use raft::storage::{GetEntriesContext, MemStorage};
 use raft::*;
 use raft_proto::*;
 use slog::Logger;
@@ -3121,7 +3121,10 @@ fn test_step_ignore_config() {
     let mut we = empty_entry(1, 3);
     we.set_entry_type(EntryType::EntryNormal);
     let wents = vec![we];
-    let entries = r.raft_log.entries(index + 1, None, None).expect("");
+    let entries = r
+        .raft_log
+        .entries(index + 1, None, GetEntriesContext::Test)
+        .expect("");
     assert_eq!(entries, wents);
     assert_eq!(r.pending_conf_index, pending_conf_index);
 }
@@ -4844,7 +4847,7 @@ fn prepare_request_snapshot() -> (Network, Snapshot) {
     let msg = new_message_with_entries(1, 1, MessageType::MsgPropose, vec![test_entries]);
     nt.send(vec![msg]);
 
-    let s = nt.storage[&1].snapshot(0).unwrap();
+    let s = nt.storage[&1].snapshot(0, 0).unwrap();
     (nt, s)
 }
 

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -918,7 +918,7 @@ fn test_raw_node_with_async_entries() {
     assert_eq!(msgs.len(), 0);
     let _ = raw_node.advance_append(rd);
 
-    // Entries are sent when the entries are ready which is informed by `send_append`.
+    // Entries are sent when the entries are ready which is informed by `on_entries_fetched`.
     s.wl().trigger_log_unavailable(false);
     let context = s.wl().take_get_entries_context().unwrap();
     raw_node.on_entries_fetched(context);

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -920,7 +920,8 @@ fn test_raw_node_with_async_entries() {
 
     // Entries are sent when the entries are ready which is informed by `send_append`.
     s.wl().trigger_log_unavailable(false);
-    raw_node.send_append(2);
+    let context = s.wl().take_get_entries_context().unwrap();
+    raw_node.on_entries_fetched(context);
     let rd = raw_node.ready();
     let entries = rd.entries().clone();
     s.wl().append(&entries).unwrap();

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -304,7 +304,9 @@ fn test_raw_node_propose_and_conf_change() {
         // will not reflect any unstable entries that we'll only be presented
         // with in the next Ready.
         let last_index = s.last_index().unwrap();
-        let entries = s.entries(last_index - 1, last_index + 1, NO_LIMIT).unwrap();
+        let entries = s
+            .entries(last_index - 1, last_index + 1, NO_LIMIT, None)
+            .unwrap();
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].get_data(), b"somedata");
         if cc.as_v1().is_some() {
@@ -422,7 +424,9 @@ fn test_raw_node_joint_auto_leave() {
     // will not reflect any unstable entries that we'll only be presented
     // with in the next Ready.
     let last_index = s.last_index().unwrap();
-    let entries = s.entries(last_index - 1, last_index + 1, NO_LIMIT).unwrap();
+    let entries = s
+        .entries(last_index - 1, last_index + 1, NO_LIMIT, None)
+        .unwrap();
     assert_eq!(entries.len(), 2);
     assert_eq!(entries[0].get_data(), b"somedata");
     assert_eq!(entries[1].get_entry_type(), EntryType::EntryConfChangeV2);
@@ -515,7 +519,9 @@ fn test_raw_node_propose_add_duplicate_node() {
     let last_index = s.last_index().unwrap();
 
     // the last three entries should be: ConfChange cc1, cc1, cc2
-    let mut entries = s.entries(last_index - 2, last_index + 1, None).unwrap();
+    let mut entries = s
+        .entries(last_index - 2, last_index + 1, None, None)
+        .unwrap();
     assert_eq!(entries.len(), 3);
     assert_eq!(entries[0].take_data(), ccdata1);
     assert_eq!(entries[2].take_data(), ccdata2);
@@ -1698,8 +1704,9 @@ impl Storage for IgnoreSizeHintMemStorage {
         low: u64,
         high: u64,
         _max_size: impl Into<Option<u64>>,
+        async_to: Option<u64>,
     ) -> Result<Vec<Entry>> {
-        self.inner.entries(low, high, u64::MAX)
+        self.inner.entries(low, high, u64::MAX, async_to)
     }
 
     fn term(&self, idx: u64) -> Result<u64> {

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -309,7 +309,7 @@ fn test_raw_node_propose_and_conf_change() {
                 last_index - 1,
                 last_index + 1,
                 NO_LIMIT,
-                GetEntriesContext::none(),
+                GetEntriesContext::empty(false),
             )
             .unwrap();
         assert_eq!(entries.len(), 2);
@@ -434,7 +434,7 @@ fn test_raw_node_joint_auto_leave() {
             last_index - 1,
             last_index + 1,
             NO_LIMIT,
-            GetEntriesContext::none(),
+            GetEntriesContext::empty(false),
         )
         .unwrap();
     assert_eq!(entries.len(), 2);
@@ -534,7 +534,7 @@ fn test_raw_node_propose_add_duplicate_node() {
             last_index - 2,
             last_index + 1,
             None,
-            GetEntriesContext::none(),
+            GetEntriesContext::empty(false),
         )
         .unwrap();
     assert_eq!(entries.len(), 3);

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -309,7 +309,7 @@ fn test_raw_node_propose_and_conf_change() {
                 last_index - 1,
                 last_index + 1,
                 NO_LIMIT,
-                GetEntriesContext::Test,
+                GetEntriesContext::test(),
             )
             .unwrap();
         assert_eq!(entries.len(), 2);
@@ -434,7 +434,7 @@ fn test_raw_node_joint_auto_leave() {
             last_index - 1,
             last_index + 1,
             NO_LIMIT,
-            GetEntriesContext::Test,
+            GetEntriesContext::test(),
         )
         .unwrap();
     assert_eq!(entries.len(), 2);
@@ -534,7 +534,7 @@ fn test_raw_node_propose_add_duplicate_node() {
             last_index - 2,
             last_index + 1,
             None,
-            GetEntriesContext::Test,
+            GetEntriesContext::test(),
         )
         .unwrap();
     assert_eq!(entries.len(), 3);

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -309,7 +309,7 @@ fn test_raw_node_propose_and_conf_change() {
                 last_index - 1,
                 last_index + 1,
                 NO_LIMIT,
-                GetEntriesContext::test(),
+                GetEntriesContext::none(),
             )
             .unwrap();
         assert_eq!(entries.len(), 2);
@@ -434,7 +434,7 @@ fn test_raw_node_joint_auto_leave() {
             last_index - 1,
             last_index + 1,
             NO_LIMIT,
-            GetEntriesContext::test(),
+            GetEntriesContext::none(),
         )
         .unwrap();
     assert_eq!(entries.len(), 2);
@@ -534,7 +534,7 @@ fn test_raw_node_propose_add_duplicate_node() {
             last_index - 2,
             last_index + 1,
             None,
-            GetEntriesContext::test(),
+            GetEntriesContext::none(),
         )
         .unwrap();
     assert_eq!(entries.len(), 3);

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raft-proto"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["The TiKV Project Developers"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -75,6 +75,9 @@ pub enum StorageError {
     /// The log is not available.
     #[error("log unavailable")]
     Unavailable,
+    /// The log is being fetched.
+    #[error("log is temporarily unavailable")]
+    LogTemporarilyUnavailable,
     /// The snapshot is out of date.
     #[error("snapshot out of date")]
     SnapshotOutOfDate,
@@ -93,6 +96,10 @@ impl PartialEq for StorageError {
             (self, other),
             (StorageError::Compacted, StorageError::Compacted)
                 | (StorageError::Unavailable, StorageError::Unavailable)
+                | (
+                    StorageError::LogTemporarilyUnavailable,
+                    StorageError::LogTemporarilyUnavailable
+                )
                 | (
                     StorageError::SnapshotOutOfDate,
                     StorageError::SnapshotOutOfDate

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,7 +536,7 @@ pub use raw_node::is_empty_snap;
 pub use raw_node::{LightReady, Peer, RawNode, Ready, SnapshotStatus};
 pub use read_only::{ReadOnlyOption, ReadState};
 pub use status::Status;
-pub use storage::{RaftState, Storage};
+pub use storage::{GetEntriesContext, RaftState, Storage};
 pub use tracker::{Inflights, Progress, ProgressState, ProgressTracker};
 pub use util::majority;
 

--- a/src/log_unstable.rs
+++ b/src/log_unstable.rs
@@ -173,10 +173,7 @@ impl Unstable {
             self.entries.truncate((after - off) as usize);
         }
         self.entries.extend_from_slice(ents);
-        self.entries_size += ents
-            .iter()
-            .map(|ent| entry_approximate_size(ent))
-            .sum::<usize>();
+        self.entries_size += ents.iter().map(entry_approximate_size).sum::<usize>();
     }
 
     /// Returns a slice of entries between the high and low.
@@ -393,10 +390,7 @@ mod test {
     #[test]
     fn test_stable_snapshot_and_entries() {
         let ents = vec![new_entry(5, 1), new_entry(5, 2), new_entry(6, 3)];
-        let entries_size = ents
-            .iter()
-            .map(|ent| entry_approximate_size(ent))
-            .sum::<usize>();
+        let entries_size = ents.iter().map(entry_approximate_size).sum::<usize>();
         let mut u = Unstable {
             entries: ents.clone(),
             entries_size,
@@ -467,10 +461,7 @@ mod test {
         ];
 
         for (entries, offset, snapshot, to_append, woffset, wentries) in tests {
-            let entries_size = entries
-                .iter()
-                .map(|ent| entry_approximate_size(ent))
-                .sum::<usize>();
+            let entries_size = entries.iter().map(entry_approximate_size).sum::<usize>();
             let mut u = Unstable {
                 entries,
                 entries_size,
@@ -481,10 +472,7 @@ mod test {
             u.truncate_and_append(&to_append);
             assert_eq!(u.offset, woffset);
             assert_eq!(u.entries, wentries);
-            let entries_size = wentries
-                .iter()
-                .map(|ent| entry_approximate_size(ent))
-                .sum::<usize>();
+            let entries_size = wentries.iter().map(entry_approximate_size).sum::<usize>();
             assert_eq!(u.entries_size, entries_size);
         }
     }

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -34,7 +34,7 @@ use slog::{debug, error, info, o, trace, warn};
 use super::errors::{Error, Result, StorageError};
 use super::raft_log::RaftLog;
 use super::read_only::{ReadOnly, ReadOnlyOption, ReadState};
-use super::storage::{GetEntriesContext, Storage};
+use super::storage::{GetEntriesContext, GetEntriesFor, Storage};
 use super::Config;
 use crate::confchange::Changer;
 use crate::quorum::VoteResult;
@@ -792,7 +792,7 @@ impl<T: Storage> RaftCore<T> {
             let ents = self.raft_log.entries(
                 pr.next_idx,
                 self.max_msg_size,
-                GetEntriesContext::SendAppend { to },
+                GetEntriesContext(GetEntriesFor::SendAppend { to }),
             );
             if !allow_empty && ents.as_ref().ok().map_or(true, |e| e.is_empty()) {
                 return false;
@@ -1511,7 +1511,7 @@ impl<T: Storage> Raft<T> {
                 first_index,
                 self.raft_log.committed + 1,
                 None,
-                GetEntriesContext::TransferLeader,
+                GetEntriesContext(GetEntriesFor::TransferLeader),
             )
             .unwrap_or_else(|e| {
                 fatal!(
@@ -2172,7 +2172,7 @@ impl<T: Storage> Raft<T> {
                 last_commit + 1,
                 self.raft_log.committed + 1,
                 None,
-                GetEntriesContext::CommitByVote,
+                GetEntriesContext(GetEntriesFor::CommitByVote),
             )
             .unwrap_or_else(|e| {
                 fatal!(

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1042,11 +1042,6 @@ impl<T: Storage> Raft<T> {
         }
     }
 
-    // /// Returns true to indicate that there will probably be some readiness need to be handled.
-    // pub fn on_entries_fetched(&mut self, range: (u64, u64)) -> bool {
-    //     if self.send_append()
-    // }
-
     // TODO: revoke pub when there is a better way to test.
     /// Run by followers and candidates after self.election_timeout.
     ///

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -757,12 +757,7 @@ impl<T: Storage> RaftCore<T> {
     /// Sends an append RPC with new entries (if any) and the current commit index to the given
     /// peer.
     fn send_append(&mut self, to: u64, pr: &mut Progress, msgs: &mut Vec<Message>) {
-        // Sending multiple (size-limited) in-flight messages at once
-        // are allowed (such as when transitioning from probe to
-        // replicate, or when freeTo() covers multiple messages). If
-        // we have more entries to send, send as many messages as we
-        // can (without sending empty messages for the commit index)
-        while self.maybe_send_append(to, pr, false, msgs) {}
+        self.maybe_send_append(to, pr, true, msgs);
     }
 
     /// Sends an append RPC with new entries to the given peer,
@@ -862,9 +857,15 @@ impl<T: Storage> Raft<T> {
 
     /// Sends an append RPC with new entries (if any) and the current commit index to the given
     /// peer.
-    pub fn send_append(&mut self, to: u64) {
+    pub fn send_append(&mut self, to: u64, exhaust: bool) {
         let pr = self.prs.get_mut(to).unwrap();
-        self.r.send_append(to, pr, &mut self.msgs);
+        if exhaust {
+            // If we have more entries to send, send as many messages as we
+            // can (without sending empty messages for the commit index)
+            while self.r.maybe_send_append(to, pr, false, &mut self.msgs) {}
+        } else {
+            self.r.send_append(to, pr, &mut self.msgs)
+        }
     }
 
     /// Sends RPC, with entries to all peers that are not up-to-date
@@ -876,9 +877,7 @@ impl<T: Storage> Raft<T> {
         self.prs
             .iter_mut()
             .filter(|&(id, _)| *id != self_id)
-            .for_each(|(id, pr)| {
-                core.send_append(*id, pr, msgs);
-            });
+            .for_each(|(id, pr)| core.send_append(*id, pr, msgs));
     }
 
     /// Broadcasts heartbeats to all the followers if it's leader.
@@ -1733,7 +1732,7 @@ impl<T: Storage> Raft<T> {
                 if pr.state == ProgressState::Replicate {
                     pr.become_probe();
                 }
-                self.send_append(m.from);
+                self.send_append(m.from, false);
             }
             return;
         }
@@ -1764,7 +1763,7 @@ impl<T: Storage> Raft<T> {
                 self.bcast_append()
             }
         } else if old_paused {
-            self.send_append(m.from);
+            self.send_append(m.from, false);
         }
         // Hack to get around borrow check. It may be possible to move L1448 above L1433 to
         // get around the problem. But here choose to keep consistent with Etcd.

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -2064,7 +2064,7 @@ impl<T: Storage> Raft<T> {
                         e.set_entry_type(EntryType::EntryNormal);
                     }
                 }
-                if !self.append_entry(&mut m.mut_entries()) {
+                if !self.append_entry(m.mut_entries()) {
                     // return ProposalDropped when uncommitted size limit is reached
                     debug!(
                         self.logger,

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -397,7 +397,7 @@ impl<T: Storage> RaftLog<T> {
     #[doc(hidden)]
     pub fn all_entries(&self) -> Vec<Entry> {
         let first_index = self.first_index();
-        match self.entries(first_index, None, GetEntriesContext::none()) {
+        match self.entries(first_index, None, GetEntriesContext::empty(false)) {
             Err(e) => {
                 // try again if there was a racing compaction
                 if e == Error::Store(StorageError::Compacted) {
@@ -806,7 +806,7 @@ mod test {
             if index != windex {
                 panic!("#{}: last_index = {}, want {}", i, index, windex);
             }
-            match raft_log.entries(1, None, GetEntriesContext::none()) {
+            match raft_log.entries(1, None, GetEntriesContext::empty(false)) {
                 Err(e) => panic!("#{}: unexpected error {}", i, e),
                 Ok(ref g) if g != wents => panic!("#{}: logEnts = {:?}, want {:?}", i, &g, &wents),
                 _ => {
@@ -864,7 +864,7 @@ mod test {
 
         prev = raft_log.last_index();
         let ents = raft_log
-            .entries(prev, None, GetEntriesContext::none())
+            .entries(prev, None, GetEntriesContext::empty(false))
             .expect("unexpected error");
         assert_eq!(1, ents.len());
     }
@@ -1259,7 +1259,7 @@ mod test {
 
         for (i, &(from, to, limit, ref w, wpanic)) in tests.iter().enumerate() {
             let res = panic::catch_unwind(AssertUnwindSafe(|| {
-                raft_log.slice(from, to, Some(limit), GetEntriesContext::none())
+                raft_log.slice(from, to, Some(limit), GetEntriesContext::empty(false))
             }));
             if res.is_err() ^ wpanic {
                 panic!("#{}: panic = {}, want {}: {:?}", i, true, false, res);
@@ -1503,7 +1503,7 @@ mod test {
                     raft_log.last_index() + 1,
                 );
                 let gents = raft_log
-                    .slice(from, to, None, GetEntriesContext::none())
+                    .slice(from, to, None, GetEntriesContext::empty(false))
                     .expect("");
                 if &gents != ents {
                     panic!("#{}: appended entries = {:?}, want {:?}", i, gents, ents);

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -394,6 +394,7 @@ impl<T: Storage> RaftLog<T> {
     }
 
     /// Returns all the entries. Only used by tests.
+    #[doc(hidden)]
     pub fn all_entries(&self) -> Vec<Entry> {
         let first_index = self.first_index();
         match self.entries(first_index, None, GetEntriesContext::none()) {

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -396,7 +396,7 @@ impl<T: Storage> RaftLog<T> {
     /// Returns all the entries. Only used by tests.
     pub fn all_entries(&self) -> Vec<Entry> {
         let first_index = self.first_index();
-        match self.entries(first_index, None, GetEntriesContext::test()) {
+        match self.entries(first_index, None, GetEntriesContext::none()) {
             Err(e) => {
                 // try again if there was a racing compaction
                 if e == Error::Store(StorageError::Compacted) {
@@ -805,7 +805,7 @@ mod test {
             if index != windex {
                 panic!("#{}: last_index = {}, want {}", i, index, windex);
             }
-            match raft_log.entries(1, None, GetEntriesContext::test()) {
+            match raft_log.entries(1, None, GetEntriesContext::none()) {
                 Err(e) => panic!("#{}: unexpected error {}", i, e),
                 Ok(ref g) if g != wents => panic!("#{}: logEnts = {:?}, want {:?}", i, &g, &wents),
                 _ => {
@@ -863,7 +863,7 @@ mod test {
 
         prev = raft_log.last_index();
         let ents = raft_log
-            .entries(prev, None, GetEntriesContext::test())
+            .entries(prev, None, GetEntriesContext::none())
             .expect("unexpected error");
         assert_eq!(1, ents.len());
     }
@@ -1258,7 +1258,7 @@ mod test {
 
         for (i, &(from, to, limit, ref w, wpanic)) in tests.iter().enumerate() {
             let res = panic::catch_unwind(AssertUnwindSafe(|| {
-                raft_log.slice(from, to, Some(limit), GetEntriesContext::test())
+                raft_log.slice(from, to, Some(limit), GetEntriesContext::none())
             }));
             if res.is_err() ^ wpanic {
                 panic!("#{}: panic = {}, want {}: {:?}", i, true, false, res);
@@ -1502,7 +1502,7 @@ mod test {
                     raft_log.last_index() + 1,
                 );
                 let gents = raft_log
-                    .slice(from, to, None, GetEntriesContext::test())
+                    .slice(from, to, None, GetEntriesContext::none())
                     .expect("");
                 if &gents != ents {
                     panic!("#{}: appended entries = {:?}, want {:?}", i, gents, ents);

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -411,7 +411,7 @@ impl<T: Storage> RawNode<T> {
     }
 
     /// Trigger a send append msg to the target peer.
-    pub fn send_append(&mut self, to: u64) -> bool {
+    pub fn send_append(&mut self, to: u64) {
         self.raft.send_append(to)
     }
 

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -426,7 +426,7 @@ impl<T: Storage> RawNode<T> {
                     self.raft.send_append(to)
                 }
             }
-            GetEntriesFor::Empty(can_async) if can_async == true => {}
+            GetEntriesFor::Empty(can_async) if can_async => {}
             _ => panic!("shouldn't call callback on non-async context"),
         }
     }

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -413,7 +413,13 @@ impl<T: Storage> RawNode<T> {
     /// A callback when entries are fetched asynchronously .
     pub fn on_entries_fetched(&mut self, context: GetEntriesContext) {
         match context.0 {
-            GetEntriesFor::SendAppend { to } => self.raft.send_append(to, true),
+            GetEntriesFor::SendAppend { to, aggressively } => {
+                if aggressively {
+                    self.raft.send_append_aggressively(to)
+                } else {
+                    self.raft.send_append(to)
+                }
+            }
             _ => unreachable!(),
         }
     }

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -420,7 +420,7 @@ impl<T: Storage> RawNode<T> {
                     self.raft.send_append(to)
                 }
             }
-            _ => unreachable!(),
+            _ => unimplemented!(),
         }
     }
 

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -30,7 +30,7 @@ use crate::eraftpb::{ConfState, Entry, EntryType, HardState, Message, MessageTyp
 use crate::errors::{Error, Result};
 use crate::read_only::ReadState;
 use crate::{config::Config, StateRole};
-use crate::{Raft, SoftState, Status, Storage};
+use crate::{GetEntriesContext, Raft, SoftState, Status, Storage};
 
 use slog::info;
 
@@ -410,9 +410,12 @@ impl<T: Storage> RawNode<T> {
         Err(Error::StepPeerNotFound)
     }
 
-    /// Trigger a send append msg to the target peer.
-    pub fn send_append(&mut self, to: u64) {
-        self.raft.send_append(to, true)
+    /// A callback when entries are fetched asynchronously .
+    pub fn on_entries_fetched(&mut self, context: GetEntriesContext) {
+        match context {
+            GetEntriesContext::SendAppend { to } => self.raft.send_append(to, true),
+            _ => unreachable!(),
+        }
     }
 
     /// Generates a LightReady that has the committed entries and messages but no commit index.

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -412,7 +412,7 @@ impl<T: Storage> RawNode<T> {
 
     /// Trigger a send append msg to the target peer.
     pub fn send_append(&mut self, to: u64) {
-        self.raft.send_append(to)
+        self.raft.send_append(to, true)
     }
 
     /// Generates a LightReady that has the committed entries and messages but no commit index.

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -413,6 +413,10 @@ impl<T: Storage> RawNode<T> {
     /// A callback when entries are fetched asynchronously.
     /// The context should provide the context passed from Storage.entires().
     /// See more in the comment of Storage.entires().
+    ///
+    /// # Panics
+    ///
+    /// Panics if passed with the context of context.can_async() == false
     pub fn on_entries_fetched(&mut self, context: GetEntriesContext) {
         match context.0 {
             GetEntriesFor::SendAppend { to, aggressively } => {

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -410,6 +410,11 @@ impl<T: Storage> RawNode<T> {
         Err(Error::StepPeerNotFound)
     }
 
+    /// Trigger a send append msg to the target peer.
+    pub fn send_append(&mut self, to: u64) -> bool {
+        self.raft.send_append(to)
+    }
+
     /// Generates a LightReady that has the committed entries and messages but no commit index.
     fn gen_light_ready(&mut self) -> LightReady {
         let mut rd = LightReady::default();

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -426,8 +426,8 @@ impl<T: Storage> RawNode<T> {
                     self.raft.send_append(to)
                 }
             }
-            GetEntriesFor::Empty(_) => {}
-            _ => unimplemented!(),
+            GetEntriesFor::Empty(can_async) if can_async == true => {}
+            _ => panic!("shouldn't call callback on non-async context"),
         }
     }
 

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -30,7 +30,7 @@ use crate::eraftpb::{ConfState, Entry, EntryType, HardState, Message, MessageTyp
 use crate::errors::{Error, Result};
 use crate::read_only::ReadState;
 use crate::{config::Config, StateRole};
-use crate::{GetEntriesContext, Raft, SoftState, Status, Storage};
+use crate::{storage::GetEntriesFor, GetEntriesContext, Raft, SoftState, Status, Storage};
 
 use slog::info;
 
@@ -412,8 +412,8 @@ impl<T: Storage> RawNode<T> {
 
     /// A callback when entries are fetched asynchronously .
     pub fn on_entries_fetched(&mut self, context: GetEntriesContext) {
-        match context {
-            GetEntriesContext::SendAppend { to } => self.raft.send_append(to, true),
+        match context.0 {
+            GetEntriesFor::SendAppend { to } => self.raft.send_append(to, true),
             _ => unreachable!(),
         }
     }

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -410,7 +410,9 @@ impl<T: Storage> RawNode<T> {
         Err(Error::StepPeerNotFound)
     }
 
-    /// A callback when entries are fetched asynchronously .
+    /// A callback when entries are fetched asynchronously.
+    /// The context should provide the context passed from Storage.entires().
+    /// See more in the comment of Storage.entires().
     pub fn on_entries_fetched(&mut self, context: GetEntriesContext) {
         match context.0 {
             GetEntriesFor::SendAppend { to, aggressively } => {
@@ -420,6 +422,7 @@ impl<T: Storage> RawNode<T> {
                     self.raft.send_append(to)
                 }
             }
+            GetEntriesFor::Empty(_) => {}
             _ => unimplemented!(),
         }
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -57,6 +57,7 @@ impl RaftState {
 }
 
 /// Records the context of the caller who calls entries() of Storage trait.
+#[derive(Debug)]
 pub struct GetEntriesContext(pub(crate) GetEntriesFor);
 
 impl GetEntriesContext {
@@ -66,6 +67,7 @@ impl GetEntriesContext {
     }
 }
 
+#[derive(Debug)]
 pub(crate) enum GetEntriesFor {
     // for sending entries to followers
     SendAppend {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -61,12 +61,12 @@ impl RaftState {
 pub struct GetEntriesContext(pub(crate) GetEntriesFor);
 
 impl GetEntriesContext {
-    /// Used for callers out of raft which dosen't support fetch entries asynchrouously.
+    /// Used for callers out of raft which dosen't support fetching entries asynchrouously.
     pub fn none() -> Self {
         GetEntriesContext(GetEntriesFor::None)
     }
 
-    /// Check if the caller's context support fetch entries asynchrouously.
+    /// Check if the caller's context support fetching entries asynchrouously.
     pub fn can_async(&self) -> bool {
         matches!(self.0, GetEntriesFor::SendAppend { .. })
     }
@@ -108,8 +108,8 @@ pub trait Storage {
     /// the slice of entries returned will always have length at least 1 if entries are
     /// found in the range.
     ///
-    /// Entries are supported to be fetched asynchorously depending on the context. Async is optional,
-    /// storage should check context.can_async() first and decide whether to fetch entries asynchorously
+    /// Entries are supported to be fetched asynchorously depending on the context. Async is optional.
+    /// Storage should check context.can_async() first and decide whether to fetch entries asynchorously
     /// based on its own implementation. If the entries are fetched asynchorously, storage should return
     /// LogTemporarilyUnavailable. Application needs to call `on_entries_fetched(context)` to trigger
     /// re-fetch of the entries after the storage finishes fetching the entries.   
@@ -496,7 +496,7 @@ impl Storage for MemStorage {
     }
 
     /// Implements the Storage trait.
-    fn snapshot(&self, request_index: u64, _request_peer: u64) -> Result<Snapshot> {
+    fn snapshot(&self, request_index: u64, _to: u64) -> Result<Snapshot> {
         let mut core = self.wl();
         if core.trigger_snap_unavailable {
             core.trigger_snap_unavailable = false;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -149,6 +149,7 @@ pub trait Storage {
 
 /// The Memory Storage Core instance holds the actual state of the storage struct. To access this
 /// value, use the `rl` and `wl` functions on the main MemStorage implementation.
+#[derive(Default)]
 pub struct MemStorageCore {
     raft_state: RaftState,
     // entries[i] has raft log position i+snapshot.get_metadata().index
@@ -162,21 +163,6 @@ pub struct MemStorageCore {
     trigger_log_unavailable: bool,
     // Stores get entries context.
     get_entries_context: Option<GetEntriesContext>,
-}
-
-impl Default for MemStorageCore {
-    fn default() -> MemStorageCore {
-        MemStorageCore {
-            raft_state: Default::default(),
-            entries: vec![],
-            // Every time a snapshot is applied to the storage, the metadata will be stored here.
-            snapshot_metadata: Default::default(),
-            // When starting from scratch populate the list with a dummy entry at term zero.
-            trigger_snap_unavailable: false,
-            trigger_log_unavailable: false,
-            get_entries_context: None,
-        }
-    }
 }
 
 impl MemStorageCore {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -68,10 +68,7 @@ impl GetEntriesContext {
 
     /// Check if the caller's context support fetch entries asynchrouously.
     pub fn can_async(&self) -> bool {
-        match self.0 {
-            GetEntriesFor::SendAppend { .. } => true,
-            _ => false,
-        }
+        matches!(self.0, GetEntriesFor::SendAppend { .. })
     }
 }
 
@@ -457,11 +454,9 @@ impl Storage for MemStorage {
             );
         }
 
-        if core.trigger_log_unavailable {
-            if context.can_async() {
-                core.get_entries_context = Some(context);
-                return Err(Error::Store(StorageError::LogTemporarilyUnavailable));
-            }
+        if core.trigger_log_unavailable && context.can_async() {
+            core.get_entries_context = Some(context);
+            return Err(Error::Store(StorageError::LogTemporarilyUnavailable));
         }
 
         let offset = core.entries[0].index;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -117,7 +117,7 @@ pub trait Storage {
     /// Entries are supported to be fetched asynchorously depending on the context. Async is optional.
     /// Storage should check context.can_async() first and decide whether to fetch entries asynchorously
     /// based on its own implementation. If the entries are fetched asynchorously, storage should return
-    /// LogTemporarilyUnavailable. Application needs to call `on_entries_fetched(context)` to trigger
+    /// LogTemporarilyUnavailable, and application needs to call `on_entries_fetched(context)` to trigger
     /// re-fetch of the entries after the storage finishes fetching the entries.   
     ///
     /// # Panics

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -424,10 +424,8 @@ impl Storage for MemStorage {
             );
         }
 
-        if async_to.is_some() {
-            if core.trigger_log_unavailable {
-                return Err(Error::Store(StorageError::LogTemporarilyUnavailable));
-            }
+        if async_to.is_some() && core.trigger_log_unavailable {
+            return Err(Error::Store(StorageError::LogTemporarilyUnavailable));
         }
 
         let offset = core.entries[0].index;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -78,6 +78,8 @@ pub(crate) enum GetEntriesFor {
     SendAppend {
         /// the peer id to which the entries are going to send
         to: u64,
+        /// whether to exhaust all the entries
+        aggressively: bool,
     },
     // for getting committed entries in a ready
     GenReady,


### PR DESCRIPTION
Support fetch entry in async way, here are some changes:
- Add an error `LogTemporarilyUnavailable`
- Add a field `context` to `entries()`
   - Some process still need to fetch the entries in sync way, add a constraint to limit the condition when async fetch is permitted.
   - when entries are fetched asynchronously , it should return error `LogTemporarilyUnavailable`
- Add a public function `on_entries_fetched` for triggering refetch the logs after async log fetch is finished.