### PR TITLE
Fix async entries fetched callback panic on removed node

### DIFF
--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -932,7 +932,7 @@ fn test_raw_node_with_async_entries() {
     let _ = raw_node.advance_append(rd);
 }
 
-// Test entries are handled properly when they are fetched asynchronously
+// Test async fetch entries works well when there is a remove node conf-change.
 #[test]
 fn test_raw_node_with_async_entries_to_removed_node() {
     let l = default_logger();

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -932,6 +932,60 @@ fn test_raw_node_with_async_entries() {
     let _ = raw_node.advance_append(rd);
 }
 
+// Test entries are handled properly when they are fetched asynchronously
+#[test]
+fn test_raw_node_with_async_entries_to_removed_node() {
+    let l = default_logger();
+    let mut cfg = new_test_config(1, 10, 1);
+    cfg.max_size_per_msg = 2048;
+    let s = new_storage();
+    let mut raw_node = new_raw_node_with_config(vec![1, 2], &cfg, s.clone(), &l);
+
+    raw_node.raft.become_candidate();
+    raw_node.raft.become_leader();
+
+    let rd = raw_node.ready();
+    s.wl().append(rd.entries()).unwrap();
+    let _ = raw_node.advance(rd);
+
+    let data: Vec<u8> = vec![1; 1000];
+    for _ in 0..10 {
+        raw_node.propose(vec![], data.to_vec()).unwrap();
+    }
+
+    let rd = raw_node.ready();
+    let entries = rd.entries().clone();
+    assert_eq!(entries.len(), 10);
+    s.wl().append(&entries).unwrap();
+    let msgs = rd.messages();
+    // First append has two entries: the empty entry to confirm the
+    // election, and the first proposal (only one proposal gets sent
+    // because we're in probe state).
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(msgs[0].msg_type, MessageType::MsgAppend);
+    assert_eq!(msgs[0].entries.len(), 2);
+    let _ = raw_node.advance_append(rd);
+
+    s.wl().trigger_log_unavailable(true);
+
+    // Become replicate state
+    let mut append_response = new_message(2, 1, MessageType::MsgAppendResponse, 0);
+    append_response.set_term(2);
+    append_response.set_index(2);
+    raw_node.step(append_response).unwrap();
+
+    raw_node.apply_conf_change(&remove_node(2)).unwrap();
+
+    // Entries are not sent due to the node is removed.
+    s.wl().trigger_log_unavailable(false);
+    let context = s.wl().take_get_entries_context().unwrap();
+    raw_node.on_entries_fetched(context);
+    let rd = raw_node.ready();
+    assert_eq!(rd.entries().len(), 0);
+    assert_eq!(rd.messages().len(), 0);
+    let _ = raw_node.advance_append(rd);
+}
+
 #[test]
 fn test_raw_node_with_async_apply() {
     let l = default_logger();

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -420,6 +420,10 @@ impl<T: Storage> RawNode<T> {
     pub fn on_entries_fetched(&mut self, context: GetEntriesContext) {
         match context.0 {
             GetEntriesFor::SendAppend { to, aggressively } => {
+                if self.raft.prs().get(to).is_none() {
+                    // the peer has been removed, do nothing
+                    return;
+                }
                 if aggressively {
                     self.raft.send_append_aggressively(to)
                 } else {


### PR DESCRIPTION
If there has conf change been applied before the async fetched callback is called, it would be panic due to missing progress for the peer. 
 
![image](https://user-images.githubusercontent.com/13497871/153411112-04d14bad-8886-43ed-b51a-a8628946c7c8.png)

So this PR checks the validation of the peer id in the context