### PR TITLE
*: fix missing features

### DIFF
--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 
 [features]
 default = ["protobuf-codec"]
-protobuf-codec = ["protobuf-build/protobuf-codec", "bytes"]
+protobuf-codec = ["protobuf-build/protobuf-codec", "bytes", "protobuf/bytes"]
 prost-codec = ["protobuf-build/prost-codec", "prost", "lazy_static"]
 
 [build-dependencies]


### PR DESCRIPTION
Cargo seems enable protobuf bytes features when building in the workspace. But it will not when it's included as a third project's dependency. This PR fixes the problem by enabling bytes explicitly.

Close #463 