### PR TITLE
Ignore async entries when leadership or term is changed

### DIFF
--- a/src/raft.rs
+++ b/src/raft.rs
@@ -805,6 +805,7 @@ impl<T: Storage> RaftCore<T> {
                 self.max_msg_size,
                 GetEntriesContext(GetEntriesFor::SendAppend {
                     to,
+                    term: self.term,
                     aggressively: !allow_empty,
                 }),
             );

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -419,11 +419,20 @@ impl<T: Storage> RawNode<T> {
     /// Panics if passed with the context of context.can_async() == false
     pub fn on_entries_fetched(&mut self, context: GetEntriesContext) {
         match context.0 {
-            GetEntriesFor::SendAppend { to, aggressively } => {
+            GetEntriesFor::SendAppend {
+                to,
+                term,
+                aggressively,
+            } => {
                 if self.raft.prs().get(to).is_none() {
                     // the peer has been removed, do nothing
                     return;
                 }
+                if self.raft.term != term || self.raft.state != StateRole::Leader {
+                    // term or leadership has changed
+                    return;
+                }
+
                 if aggressively {
                     self.raft.send_append_aggressively(to)
                 } else {

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -424,12 +424,12 @@ impl<T: Storage> RawNode<T> {
                 term,
                 aggressively,
             } => {
-                if self.raft.prs().get(to).is_none() {
-                    // the peer has been removed, do nothing
-                    return;
-                }
                 if self.raft.term != term || self.raft.state != StateRole::Leader {
                     // term or leadership has changed
+                    return;
+                }
+                if self.raft.prs().get(to).is_none() {
+                    // the peer has been removed, do nothing
                     return;
                 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -82,6 +82,8 @@ pub(crate) enum GetEntriesFor {
     SendAppend {
         /// the peer id to which the entries are going to send
         to: u64,
+        /// the term when the request is issued
+        term: u64,
         /// whether to exhaust all the entries
         aggressively: bool,
     },


### PR DESCRIPTION
To make raft-rs robust, when calling `on_entries_fetched`, ignore the entries when leadership or term is changed. Otherwise , it may cause potential panics in `send_append`.