### PR TITLE
add prev_lead_transferee into Ready

### DIFF
--- a/src/raft.rs
+++ b/src/raft.rs
@@ -201,6 +201,9 @@ pub struct RaftCore<T: Storage> {
     /// If this is Some(id), we follow the procedure defined in raft thesis 3.10.
     pub lead_transferee: Option<u64>,
 
+    /// Just like `lead_transferee` but only used to construct a `Ready`.
+    pub(crate) prev_lead_transferee: Option<u64>,
+
     /// Only one conf change may be pending (in the log, but not yet
     /// applied) at a time. This is enforced via `pending_conf_index`, which
     /// is set to a value >= the log index of the latest pending
@@ -342,6 +345,7 @@ impl<T: Storage> Raft<T> {
                 election_timeout: c.election_tick,
                 leader_id: Default::default(),
                 lead_transferee: None,
+                prev_lead_transferee: None,
                 term: Default::default(),
                 election_elapsed: Default::default(),
                 pending_conf_index: Default::default(),
@@ -981,6 +985,7 @@ impl<T: Storage> Raft<T> {
         self.election_elapsed = 0;
         self.heartbeat_elapsed = 0;
 
+        self.prev_lead_transferee = self.lead_transferee;
         self.abort_leader_transfer();
 
         self.prs.reset_votes();

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -90,6 +90,8 @@ pub struct Ready {
 
     ss: Option<SoftState>,
 
+    prev_lead_transferee: u64,
+
     hs: Option<HardState>,
 
     read_states: Vec<ReadState>,
@@ -119,6 +121,12 @@ impl Ready {
     #[inline]
     pub fn ss(&self) -> Option<&SoftState> {
         self.ss.as_ref()
+    }
+
+    /// Maybe the peer role change is relative with a leadership transferring.
+    /// `crate::INVALID_ID` means it's not available.
+    pub fn prev_lead_transferee(&self) -> u64 {
+        self.prev_lead_transferee
     }
 
     /// The current state of a Node to be saved to stable storage.
@@ -501,6 +509,7 @@ impl<T: Storage> RawNode<T> {
         let ss = raft.soft_state();
         if ss != self.prev_ss {
             rd.ss = Some(ss);
+            rd.prev_lead_transferee = raft.prev_lead_transferee.unwrap_or_default();
         }
         let hs = raft.hard_state();
         if hs != self.prev_hs {


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

In TiKV when a leader peer is in a leadership transferring, it reports a `NotLeader` error to all CDC downstreams. Currently it doesn't know which peer will be the next leader, so CDC clients will resubscribe the region from any peers blindly.

With the patch we can return the potential next leader of the region so that clients can retry requests with a better strategy. Here is how the patch is used in TiKV: https://github.com/tikv/tikv/pull/12124.