### PR TITLE
raft:Fix one log append reject bug about MsgUnreachable msg

### DIFF
--- a/src/raft.rs
+++ b/src/raft.rs
@@ -265,6 +265,7 @@ pub struct RaftCore<T: Storage> {
 /// A struct that represents the raft consensus itself. Stores details concerning the current
 /// and possible state the system can take.
 pub struct Raft<T: Storage> {
+    /// the progress tracker of each peer.
     pub prs: ProgressTracker,
 
     /// The list of messages.

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -55,11 +55,11 @@ pub enum SnapshotStatus {
 
 /// Checks if certain message type should be used internally.
 pub fn is_local_msg(t: MessageType) -> bool {
+    // remove MessageType::MsgUnreachable
     matches!(
         t,
         MessageType::MsgHup
             | MessageType::MsgBeat
-            | MessageType::MsgUnreachable
             | MessageType::MsgSnapStatus
             | MessageType::MsgCheckQuorum
     )
@@ -805,7 +805,7 @@ mod test {
         let tests = vec![
             (MessageType::MsgHup, true),
             (MessageType::MsgBeat, true),
-            (MessageType::MsgUnreachable, true),
+            (MessageType::MsgUnreachable, false),
             (MessageType::MsgSnapStatus, true),
             (MessageType::MsgCheckQuorum, true),
             (MessageType::MsgPropose, false),


### PR DESCRIPTION
Problem Description：
close tikv/tikv#11371
1. When follower reject the appendlog requests, it will send a MsgUnreachable msg to leader
2. But the MsgUnreachable is a local type which means only be used in inner raftcore, cannot transfered by net, which leads to some logic check failed.

Solution:
1. Let the MsgUnreachable be a response message, and when leader receives, call the raft core step directly.