### PR TITLE
Fix a broken anchor link

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,7 +416,8 @@ to advance the applied index inside.
     node.advance_apply();
     ```
 
-For more information, check out an [example](examples/single_mem_node/main.rs#L113-L179).
+For more information, check out an 
+[example](https://github.com/tikv/raft-rs/blob/master/examples/single_mem_node/main.rs#L113-L179).
 
 Sometimes it's better not to block the raft machine in IO operation, so that latency of
 read/write can be more predictable and the fsync frequencey can be controlled. The crate


### PR DESCRIPTION
The origin link(https://docs.rs/raft/latest/raft/examples/single_mem_node/main.rs#L113-L179) is broken. 

The path of the corresponding code in docs.rs is (https://docs.rs/crate/raft/0.6.0/source/examples/single_mem_node/main.rs), but the line number range cannot be specified.

I changed the link to point to the corresponding code on Github.
