### PR TITLE
Add new message type and corresponding handler for group broadcast

### DIFF
--- a/proto/proto/eraftpb.proto
+++ b/proto/proto/eraftpb.proto
@@ -49,12 +49,12 @@ message Snapshot {
 // Forward is a type that tells the agent how to forward the MsgGroupBroadcast from the leader.
 //
 // Field to is the destination of forwarding.
-//
-// Field low and high (closed interval) is the range of log entries that should be send to.
+// Field log_term and index is the previous entry of log entries that should be forwarded.
+// Entries to be forwarded is the range (index, last_index].
 message Forward {
     uint64 to = 1;
-    uint64 low = 2;
-    uint64 high = 3;
+    uint64 log_term = 2;
+    uint64 index = 3;
 }
 
 enum MessageType {

--- a/proto/proto/eraftpb.proto
+++ b/proto/proto/eraftpb.proto
@@ -46,6 +46,17 @@ message Snapshot {
     SnapshotMetadata metadata = 2;
 }
 
+// Forward is a type that tells the agent how to forward the MsgGroupBroadcast from the leader.
+//
+// Field to is the destination of forwarding.
+//
+// Field low and high (closed interval) is the range of log entries that should be send to.
+message Forward {
+    uint64 to = 1;
+    uint64 low = 2;
+    uint64 high = 3;
+}
+
 enum MessageType {
     MsgHup = 0;
     MsgBeat = 1;
@@ -66,6 +77,7 @@ enum MessageType {
     MsgReadIndexResp = 16;
     MsgRequestPreVote = 17;
     MsgRequestPreVoteResponse = 18;
+    MsgGroupBroadcast = 19;
 }
 
 message Message {
@@ -89,6 +101,7 @@ message Message {
     uint64 reject_hint = 11;
     bytes context = 12;
     uint64 priority = 14;
+    repeated Forward forwards = 16;
 }
 
 message HardState {

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,10 @@ pub struct Config {
     /// rejoins the cluster.
     pub pre_vote: bool,
 
+    /// Enables follower replication.
+    /// This reduces the across-AZ traffic of cloud deployment.
+    pub follower_repl: bool,
+
     /// The range of election timeout. In some cases, we hope some nodes has less possibility
     /// to become leader. This configuration ensures that the randomized election_timeout
     /// will always be suit in [min_election_tick, max_election_tick).
@@ -112,6 +116,7 @@ impl Default for Config {
             max_inflight_msgs: 256,
             check_quorum: false,
             pre_vote: false,
+            follower_repl: false,
             min_election_tick: 0,
             max_election_tick: 0,
             read_only_option: ReadOnlyOption::Safe,

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -2965,4 +2965,19 @@ impl<T: Storage> Raft<T> {
             pr.ins.set_cap(cap);
         }
     }
+
+    /// Whether this RawNode is active recently.
+    pub fn is_recent_active(&self, id: u64) -> bool {
+        if let Some(pr) = self.prs().get(id) {
+            if pr.recent_active {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Get the next idx of peer.
+    pub fn get_next_idx(&self, id: u64) -> Option<u64> {
+        self.prs().get(id).map(|pr| pr.next_idx)
+    }
 }

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -236,6 +236,13 @@ pub struct RaftCore<T: Storage> {
     /// Enable this if greater cluster stability is preferred over faster elections.
     pub pre_vote: bool,
 
+    /// Enable follower replication.
+    ///
+    /// This enables data replication from a follower to other servers in the same available zone.
+    ///
+    /// Enable this for reducing across-AZ traffic of cloud deployment.
+    pub follower_repl: bool,
+
     skip_bcast_commit: bool,
     batch_append: bool,
 
@@ -337,6 +344,7 @@ impl<T: Storage> Raft<T> {
                 promotable: false,
                 check_quorum: c.check_quorum,
                 pre_vote: c.pre_vote,
+                follower_repl: c.follower_repl,
                 read_only: ReadOnly::new(c.read_only_option),
                 heartbeat_timeout: c.heartbeat_tick,
                 election_timeout: c.election_tick,

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -2331,6 +2331,11 @@ impl<T: Storage> Raft<T> {
                 self.leader_id = m.from;
                 self.handle_append_entries(&m);
             }
+            MessageType::MsgGroupBroadcast => {
+                self.election_elapsed = 0;
+                self.leader_id = m.from;
+                self.handle_group_broadcast(&m);
+            }
             MessageType::MsgHeartbeat => {
                 self.election_elapsed = 0;
                 self.leader_id = m.from;

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -2551,6 +2551,7 @@ impl<T: Storage> Raft<T> {
                         m_append.set_entries(ents.unwrap().into());
                         m_append.commit = m.get_commit();
                         m_append.commit_term = m.get_commit_term();
+                        info!(self.logger, "Peer {} forward MsgAppend from {} to {}", m.to, m_append.from, m_append.to);
                         self.r.send(m_append, &mut self.msgs)
                     } else {
                         warn!(

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -2984,4 +2984,14 @@ impl<T: Storage> Raft<T> {
     pub fn get_next_idx(&self, id: u64) -> Option<u64> {
         self.prs().get(id).map(|pr| pr.next_idx)
     }
+
+    /// Determine whether a progress is in Replicate state.
+    pub fn is_replicate_state(&self, id: u64) -> bool {
+        if let Some(pr) = self.prs().get(id) {
+            if pr.is_replicate_state() {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -792,6 +792,18 @@ impl<T: Storage> RawNode<T> {
     pub fn set_batch_append(&mut self, batch_append: bool) {
         self.raft.set_batch_append(batch_append)
     }
+
+    /// Whether this RawNode is active recently.
+    #[inline]
+    pub fn is_recent_active(&self, id: u64) -> bool {
+        self.raft.is_recent_active(id)
+    }
+
+    /// Get the next idx of peer.
+    #[inline]
+    pub fn get_next_idx(&self, id: u64) -> Option<u64> {
+        self.raft.get_next_idx(id)
+    }
 }
 
 #[cfg(test)]

--- a/src/tracker/progress.rs
+++ b/src/tracker/progress.rs
@@ -203,6 +203,12 @@ impl Progress {
         true
     }
 
+    /// Determine whether progress is in the Replicate state;
+    #[inline]
+    pub fn is_replicate_state(&self) -> bool {
+        return self.state == ProgressState::Replicate;
+    }
+
     /// Determine whether progress is paused.
     #[inline]
     pub fn is_paused(&self) -> bool {


### PR DESCRIPTION
Modify raft-rs to support follower replication in TiKV.
Main change:
* Add new message type: MsgGroupBroadcast, which contains information of forwarding.
* Add handler for MsgGroupBroadcast, which appends entries to local log and forward MsgAppend to other peers.