### PR TITLE
Interface of querying the information of progress

### DIFF
--- a/src/raft.rs
+++ b/src/raft.rs
@@ -2909,6 +2909,11 @@ impl<T: Storage> Raft<T> {
         self.prs().get(id).map(|pr| pr.next_idx)
     }
 
+    /// Get the matched of peer.
+    pub fn get_matched(&self, id: u64) -> Option<u64> {
+        self.prs().get(id).map(|pr| pr.matched)
+    }
+
     /// Determine whether a progress is in Replicate state.
     pub fn is_replicate_state(&self, id: u64) -> bool {
         if let Some(pr) = self.prs().get(id) {

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -2893,4 +2893,29 @@ impl<T: Storage> Raft<T> {
             pr.ins.set_cap(cap);
         }
     }
+
+    /// Whether this RawNode is active recently.
+    pub fn is_recent_active(&self, id: u64) -> bool {
+        if let Some(pr) = self.prs().get(id) {
+            if pr.recent_active {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Get the next idx of peer.
+    pub fn get_next_idx(&self, id: u64) -> Option<u64> {
+        self.prs().get(id).map(|pr| pr.next_idx)
+    }
+
+    /// Determine whether a progress is in Replicate state.
+    pub fn is_replicate_state(&self, id: u64) -> bool {
+        if let Some(pr) = self.prs().get(id) {
+            if pr.is_replicate_state() {
+                return true;
+            }
+        }
+        false
+    }
 }

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -792,6 +792,24 @@ impl<T: Storage> RawNode<T> {
     pub fn set_batch_append(&mut self, batch_append: bool) {
         self.raft.set_batch_append(batch_append)
     }
+
+    /// Whether this RawNode is active recently.
+    #[inline]
+    pub fn is_recent_active(&self, id: u64) -> bool {
+        self.raft.is_recent_active(id)
+    }
+
+    /// Get the next idx of peer.
+    #[inline]
+    pub fn get_next_idx(&self, id: u64) -> Option<u64> {
+        self.raft.get_next_idx(id)
+    }
+
+    /// Determine whether a progress is in Replicate state.
+    #[inline]
+    pub fn is_replicate_state(&self, id: u64) -> bool {
+        self.raft.is_replicate_state(id)
+    }
 }
 
 #[cfg(test)]

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -793,6 +793,12 @@ impl<T: Storage> RawNode<T> {
         self.raft.set_batch_append(batch_append)
     }
 
+    /// Get the last_idx of this peer.
+    #[inline]
+    pub fn last_idx(&self) -> u64 {
+        self.raft.raft_log.last_index()
+    }
+
     /// Whether this RawNode is active recently.
     #[inline]
     pub fn is_recent_active(&self, id: u64) -> bool {

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -805,6 +805,12 @@ impl<T: Storage> RawNode<T> {
         self.raft.get_next_idx(id)
     }
 
+    /// Get the matched of peer.
+    #[inline]
+    pub fn get_matched(&self, id: u64) -> Option<u64> {
+        self.raft.get_matched(id)
+    }
+
     /// Determine whether a progress is in Replicate state.
     #[inline]
     pub fn is_replicate_state(&self, id: u64) -> bool {

--- a/src/tracker/progress.rs
+++ b/src/tracker/progress.rs
@@ -203,6 +203,12 @@ impl Progress {
         true
     }
 
+    /// Determine whether progress is in the Replicate state;
+    #[inline]
+    pub fn is_replicate_state(&self) -> bool {
+        self.state == ProgressState::Replicate
+    }
+
     /// Determine whether progress is paused.
     #[inline]
     pub fn is_paused(&self) -> bool {


### PR DESCRIPTION
Add `RawNode` some interfaces of querying the information of progress, in order to select appropriate agent for follower replication.

Signed-off-by: LintianShi <lintian.shi@pingcap.com>