### PR TITLE
Introduce enum priority

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::raft::Priority;
+
 pub use super::read_only::{ReadOnlyOption, ReadState};
 use super::util::NO_LIMIT;
 use super::{
@@ -90,7 +92,7 @@ pub struct Config {
     pub batch_append: bool,
 
     /// The election priority of this node.
-    pub priority: u64,
+    pub priority: Priority,
 
     /// Specify maximum of uncommitted entry size.
     /// When this limit is reached, all proposals to append new log will be dropped
@@ -117,7 +119,7 @@ impl Default for Config {
             read_only_option: ReadOnlyOption::Safe,
             skip_bcast_commit: false,
             batch_append: false,
-            priority: 0,
+            priority: Priority::Normal,
             max_uncommitted_size: NO_LIMIT,
             max_committed_size_per_ready: NO_LIMIT,
         }

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -31,6 +31,7 @@ use crate::errors::{Error, Result};
 use crate::read_only::ReadState;
 use crate::{config::Config, StateRole};
 use crate::{storage::GetEntriesFor, GetEntriesContext, Raft, SoftState, Status, Storage};
+use crate::raft::Priority;
 
 use slog::info;
 
@@ -331,7 +332,7 @@ impl<T: Storage> RawNode<T> {
 
     /// Sets priority of node.
     #[inline]
-    pub fn set_priority(&mut self, priority: u64) {
+    pub fn set_priority(&mut self, priority: Priority) {
         self.raft.set_priority(priority);
     }
 


### PR DESCRIPTION
Signed-off-by: Connor1996 <zbk602423539@gmail.com>

u64 based priority is not handy, when you want to lower or raise the priority of one peer, you have to adjust all the peers'.