### PR TITLE
Update to Prost 0.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
             rust: nightly
     steps:
     - uses: actions/checkout@v2
+    - name: install Protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: setup nightly
       if: ${{ matrix.rust == 'nightly' }}
       run: rustup default nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,18 @@ jobs:
             rust: nightly
     steps:
     - uses: actions/checkout@v2
-    - name: install Protoc
-      uses: arduino/setup-protoc@v1
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - if: matrix.os == 'ubuntu-latest'
+      name: Install dependencies (ubuntu-latest)
+      run: |
+        sudo apt-get install protobuf-compiler
+    - if: matrix.os == 'macos-latest'
+      name: Install dependencies (macos-latest)
+      run: |
+        brew install protobuf
+    - if: matrix.os == 'windows-latest'
+      name: Install dependencies (windows-latest)
+      run: |
+        choco install protoc
     - name: setup nightly
       if: ${{ matrix.rust == 'nightly' }}
       run: rustup default nightly

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -18,10 +18,10 @@ protobuf-codec = ["protobuf-build/protobuf-codec", "bytes", "protobuf/bytes"]
 prost-codec = ["protobuf-build/prost-codec", "prost", "lazy_static"]
 
 [build-dependencies]
-protobuf-build = { version = "0.13", default-features = false }
+protobuf-build = { version = "0.14", default-features = false }
 
 [dependencies]
 bytes = { version = "1", optional = true }
 lazy_static = { version = "1", optional = true }
-prost = { version = "0.9", optional = true }
+prost = { version = "0.11", optional = true }
 protobuf = "2"


### PR DESCRIPTION
This PR update to Prost 0.11.

Protobuf-build has been already updated https://github.com/tikv/protobuf-build/pull/63