### PR TITLE
Make request_snapshot more safer

### DIFF
--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -4859,13 +4859,8 @@ fn test_follower_request_snapshot() {
     // Request the latest snapshot.
     let prev_snapshot_idx = s.get_metadata().index;
     let request_idx = nt.peers[&1].raft_log.committed;
-    let request_term = nt.storage.get(&1).unwrap().term(request_idx).unwrap();
     assert!(prev_snapshot_idx < request_idx);
-    nt.peers
-        .get_mut(&2)
-        .unwrap()
-        .request_snapshot(request_idx, request_term)
-        .unwrap();
+    nt.peers.get_mut(&2).unwrap().request_snapshot().unwrap();
 
     // Send the request snapshot message.
     let req_snap = nt.peers.get_mut(&2).unwrap().msgs.pop().unwrap();
@@ -4909,13 +4904,8 @@ fn test_request_snapshot_unavailable() {
     // Request the latest snapshot.
     let prev_snapshot_idx = s.get_metadata().index;
     let request_idx = nt.peers[&1].raft_log.committed;
-    let request_term = nt.storage.get(&1).unwrap().term(request_idx).unwrap();
     assert!(prev_snapshot_idx < request_idx);
-    nt.peers
-        .get_mut(&2)
-        .unwrap()
-        .request_snapshot(request_idx, request_term)
-        .unwrap();
+    nt.peers.get_mut(&2).unwrap().request_snapshot().unwrap();
 
     // Send the request snapshot message.
     let req_snap = nt.peers.get_mut(&2).unwrap().msgs.pop().unwrap();
@@ -4968,13 +4958,7 @@ fn test_request_snapshot_matched_change() {
     nt.peers.get_mut(&2).unwrap().raft_log.committed -= 1;
 
     // Request the latest snapshot.
-    let request_idx = nt.peers[&2].raft_log.committed;
-    let request_term = nt.storage.get(&2).unwrap().term(request_idx).unwrap();
-    nt.peers
-        .get_mut(&2)
-        .unwrap()
-        .request_snapshot(request_idx, request_term)
-        .unwrap();
+    nt.peers.get_mut(&2).unwrap().request_snapshot().unwrap();
     let req_snap = nt.peers.get_mut(&2).unwrap().msgs.pop().unwrap();
     // The request snapshot is ignored because it is considered as out of order.
     nt.peers.get_mut(&1).unwrap().step(req_snap).unwrap();
@@ -5018,13 +5002,7 @@ fn test_request_snapshot_none_replicate() {
         .state = ProgressState::Probe;
 
     // Request the latest snapshot.
-    let request_idx = nt.peers[&2].raft_log.committed;
-    let request_term = nt.storage.get(&2).unwrap().term(request_idx).unwrap();
-    nt.peers
-        .get_mut(&2)
-        .unwrap()
-        .request_snapshot(request_idx, request_term)
-        .unwrap();
+    nt.peers.get_mut(&2).unwrap().request_snapshot().unwrap();
     let req_snap = nt.peers.get_mut(&2).unwrap().msgs.pop().unwrap();
     nt.peers.get_mut(&1).unwrap().step(req_snap).unwrap();
     assert!(nt.peers[&1].prs().get(2).unwrap().pending_request_snapshot != 0);
@@ -5046,13 +5024,7 @@ fn test_request_snapshot_step_down() {
 
     // Recover and request the latest snapshot.
     nt.recover();
-    let request_idx = nt.peers[&2].raft_log.committed;
-    let request_term = nt.storage.get(&1).unwrap().term(request_idx).unwrap();
-    nt.peers
-        .get_mut(&2)
-        .unwrap()
-        .request_snapshot(request_idx, request_term)
-        .unwrap();
+    nt.peers.get_mut(&2).unwrap().request_snapshot().unwrap();
     nt.send(vec![new_message(3, 3, MessageType::MsgBeat, 0)]);
     assert!(
         nt.peers[&2].pending_request_snapshot == INVALID_INDEX,
@@ -5066,13 +5038,7 @@ fn test_request_snapshot_step_down() {
 fn test_request_snapshot_on_role_change() {
     let (mut nt, _) = prepare_request_snapshot();
 
-    let request_idx = nt.peers[&2].raft_log.committed;
-    let request_term = nt.storage.get(&2).unwrap().term(request_idx).unwrap();
-    nt.peers
-        .get_mut(&2)
-        .unwrap()
-        .request_snapshot(request_idx, request_term)
-        .unwrap();
+    nt.peers.get_mut(&2).unwrap().request_snapshot().unwrap();
 
     // Becoming follower does not reset pending_request_snapshot.
     let (term, id) = (nt.peers[&1].term, nt.peers[&1].id);

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -5058,6 +5058,28 @@ fn test_request_snapshot_on_role_change() {
     );
 }
 
+// Abort request snapshot if term change.
+#[test]
+fn test_request_snapshot_after_term_change() {
+    let (mut nt, _) = prepare_request_snapshot();
+
+    nt.peers.get_mut(&2).unwrap().request_snapshot().unwrap();
+
+    assert!(
+        nt.peers[&2].pending_request_snapshot != INVALID_INDEX,
+        "{}",
+        nt.peers[&2].pending_request_snapshot
+    );
+
+    let term = nt.peers[&1].term;
+    nt.peers.get_mut(&2).unwrap().reset(term + 1);
+    assert!(
+        nt.peers[&2].pending_request_snapshot == INVALID_INDEX,
+        "{}",
+        nt.peers[&2].pending_request_snapshot
+    );
+}
+
 /// Tests group commit.
 ///
 /// 1. Logs should be replicated to at least different groups before committed;

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -4859,11 +4859,12 @@ fn test_follower_request_snapshot() {
     // Request the latest snapshot.
     let prev_snapshot_idx = s.get_metadata().index;
     let request_idx = nt.peers[&1].raft_log.committed;
+    let request_term = nt.storage.get(&1).unwrap().term(request_idx).unwrap();
     assert!(prev_snapshot_idx < request_idx);
     nt.peers
         .get_mut(&2)
         .unwrap()
-        .request_snapshot(request_idx)
+        .request_snapshot(request_idx, request_term)
         .unwrap();
 
     // Send the request snapshot message.
@@ -4908,11 +4909,12 @@ fn test_request_snapshot_unavailable() {
     // Request the latest snapshot.
     let prev_snapshot_idx = s.get_metadata().index;
     let request_idx = nt.peers[&1].raft_log.committed;
+    let request_term = nt.storage.get(&1).unwrap().term(request_idx).unwrap();
     assert!(prev_snapshot_idx < request_idx);
     nt.peers
         .get_mut(&2)
         .unwrap()
-        .request_snapshot(request_idx)
+        .request_snapshot(request_idx, request_term)
         .unwrap();
 
     // Send the request snapshot message.
@@ -4967,10 +4969,11 @@ fn test_request_snapshot_matched_change() {
 
     // Request the latest snapshot.
     let request_idx = nt.peers[&2].raft_log.committed;
+    let request_term = nt.storage.get(&2).unwrap().term(request_idx).unwrap();
     nt.peers
         .get_mut(&2)
         .unwrap()
-        .request_snapshot(request_idx)
+        .request_snapshot(request_idx, request_term)
         .unwrap();
     let req_snap = nt.peers.get_mut(&2).unwrap().msgs.pop().unwrap();
     // The request snapshot is ignored because it is considered as out of order.
@@ -5016,10 +5019,11 @@ fn test_request_snapshot_none_replicate() {
 
     // Request the latest snapshot.
     let request_idx = nt.peers[&2].raft_log.committed;
+    let request_term = nt.storage.get(&2).unwrap().term(request_idx).unwrap();
     nt.peers
         .get_mut(&2)
         .unwrap()
-        .request_snapshot(request_idx)
+        .request_snapshot(request_idx, request_term)
         .unwrap();
     let req_snap = nt.peers.get_mut(&2).unwrap().msgs.pop().unwrap();
     nt.peers.get_mut(&1).unwrap().step(req_snap).unwrap();
@@ -5043,10 +5047,11 @@ fn test_request_snapshot_step_down() {
     // Recover and request the latest snapshot.
     nt.recover();
     let request_idx = nt.peers[&2].raft_log.committed;
+    let request_term = nt.storage.get(&1).unwrap().term(request_idx).unwrap();
     nt.peers
         .get_mut(&2)
         .unwrap()
-        .request_snapshot(request_idx)
+        .request_snapshot(request_idx, request_term)
         .unwrap();
     nt.send(vec![new_message(3, 3, MessageType::MsgBeat, 0)]);
     assert!(
@@ -5062,10 +5067,11 @@ fn test_request_snapshot_on_role_change() {
     let (mut nt, _) = prepare_request_snapshot();
 
     let request_idx = nt.peers[&2].raft_log.committed;
+    let request_term = nt.storage.get(&2).unwrap().term(request_idx).unwrap();
     nt.peers
         .get_mut(&2)
         .unwrap()
-        .request_snapshot(request_idx)
+        .request_snapshot(request_idx, request_term)
         .unwrap();
 
     // Becoming follower does not reset pending_request_snapshot.

--- a/harness/tests/integration_cases/test_raft_snap.rs
+++ b/harness/tests/integration_cases/test_raft_snap.rs
@@ -164,6 +164,15 @@ fn test_request_snapshot() {
         Error::RequestSnapshotDropped
     );
 
+    let term = sm.term;
+    sm.become_follower(term + 1, 2);
+
+    // Raft can not step request snapshot if last raft log's term mismatch current term.
+    assert_eq!(
+        sm.raft.as_mut().unwrap().request_snapshot().unwrap_err(),
+        Error::RequestSnapshotDropped
+    );
+
     sm.become_candidate();
     sm.become_leader();
 

--- a/harness/tests/integration_cases/test_raft_snap.rs
+++ b/harness/tests/integration_cases/test_raft_snap.rs
@@ -160,11 +160,7 @@ fn test_request_snapshot() {
 
     // Raft can not step request snapshot if there is no leader.
     assert_eq!(
-        sm.raft
-            .as_mut()
-            .unwrap()
-            .request_snapshot(INVALID_INDEX + 1, INVALID_INDEX + 1)
-            .unwrap_err(),
+        sm.raft.as_mut().unwrap().request_snapshot().unwrap_err(),
         Error::RequestSnapshotDropped
     );
 
@@ -173,11 +169,7 @@ fn test_request_snapshot() {
 
     // Raft can not step request snapshot if itself is a leader.
     assert_eq!(
-        sm.raft
-            .as_mut()
-            .unwrap()
-            .request_snapshot(INVALID_INDEX + 1, INVALID_INDEX + 1)
-            .unwrap_err(),
+        sm.raft.as_mut().unwrap().request_snapshot().unwrap_err(),
         Error::RequestSnapshotDropped
     );
 

--- a/harness/tests/integration_cases/test_raft_snap.rs
+++ b/harness/tests/integration_cases/test_raft_snap.rs
@@ -163,7 +163,7 @@ fn test_request_snapshot() {
         sm.raft
             .as_mut()
             .unwrap()
-            .request_snapshot(INVALID_INDEX + 1)
+            .request_snapshot(INVALID_INDEX + 1, INVALID_INDEX + 1)
             .unwrap_err(),
         Error::RequestSnapshotDropped
     );
@@ -176,7 +176,7 @@ fn test_request_snapshot() {
         sm.raft
             .as_mut()
             .unwrap()
-            .request_snapshot(INVALID_INDEX + 1)
+            .request_snapshot(INVALID_INDEX + 1, INVALID_INDEX + 1)
             .unwrap_err(),
         Error::RequestSnapshotDropped
     );

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -2416,7 +2416,7 @@ impl<T: Storage> Raft<T> {
         } else if self.leader_id == INVALID_ID {
             info!(
                 self.logger,
-                "drop request snapshot because of no leader";
+                "no leader; dropping request snapshot";
                 "term" => self.term,
             );
         } else if self.snap().is_some() {
@@ -2439,7 +2439,7 @@ impl<T: Storage> Raft<T> {
             }
             info! {
                 self.logger,
-                "drop reqeust snapshot because of mismatch term";
+                "mismatched term; dropping request snapshot";
                 "term" => self.term,
                 "last_term" => request_index_term,
             };

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -2439,9 +2439,9 @@ impl<T: Storage> Raft<T> {
             }
             info! {
                 self.logger,
-                "drop reqeust snapshot because of last raft log's term mismatch current term";
+                "drop reqeust snapshot because of mismatch term";
                 "term" => self.term,
-                "last_index's term" => request_index_term,
+                "last_term" => request_index_term,
             };
         }
         Err(Error::RequestSnapshotDropped)

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -186,9 +186,6 @@ pub struct RaftCore<T: Storage> {
     /// The peer is requesting snapshot, it is the index that the follower
     /// needs it to be included in a snapshot.
     pub pending_request_snapshot: u64,
-    /// The peer is requesting snapshot, it is the log term that the follower
-    /// needs it to be included in a snapshot.
-    pub pending_request_snapshot_idx_term: u64,
 
     /// The current role of this node.
     pub state: StateRole,
@@ -345,7 +342,6 @@ impl<T: Storage> Raft<T> {
                 max_inflight: c.max_inflight_msgs,
                 max_msg_size: c.max_size_per_msg,
                 pending_request_snapshot: INVALID_INDEX,
-                pending_request_snapshot_idx_term: INVALID_INDEX,
                 state: StateRole::Follower,
                 promotable: false,
                 check_quorum: c.check_quorum,
@@ -2411,7 +2407,7 @@ impl<T: Storage> Raft<T> {
     }
 
     /// Request a snapshot from a leader.
-    pub fn request_snapshot(&mut self, request_index: u64, request_term: u64) -> Result<()> {
+    pub fn request_snapshot(&mut self) -> Result<()> {
         if self.state == StateRole::Leader {
             info!(
                 self.logger,
@@ -2434,8 +2430,7 @@ impl<T: Storage> Raft<T> {
                 "there is a pending snapshot; dropping request snapshot";
             );
         } else {
-            self.pending_request_snapshot = request_index;
-            self.pending_request_snapshot_idx_term = request_term;
+            self.pending_request_snapshot = self.raft_log.last_index();
             self.send_request_snapshot();
             return Ok(());
         }
@@ -2842,7 +2837,7 @@ impl<T: Storage> Raft<T> {
         m.reject_hint = self.raft_log.last_index();
         m.to = self.leader_id;
         m.request_snapshot = self.pending_request_snapshot;
-        m.log_term = self.pending_request_snapshot_idx_term;
+        m.log_term = self.raft_log.term(m.reject_hint).unwrap();
         self.r.send(m, &mut self.msgs);
     }
 

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -828,12 +828,12 @@ mod test {
         for i in 1..=unstable_index {
             storage
                 .wl()
-                .append(&[new_entry(i as u64, i as u64)])
+                .append(&[new_entry(i, i)])
                 .expect("append failed");
         }
         let mut raft_log = RaftLog::new(storage, default_logger());
         for i in unstable_index..last_index {
-            raft_log.append(&[new_entry(i as u64 + 1, i as u64 + 1)]);
+            raft_log.append(&[new_entry(i + 1, i + 1)]);
         }
         assert!(
             raft_log.maybe_commit(last_index, last_term),

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -744,8 +744,9 @@ impl<T: Storage> RawNode<T> {
 
     /// Request a snapshot from a leader.
     /// The snapshot's index must be greater or equal to the request_index.
-    pub fn request_snapshot(&mut self, request_index: u64) -> Result<()> {
-        self.raft.request_snapshot(request_index)
+    /// The request_term is the term of request_index.
+    pub fn request_snapshot(&mut self, request_index: u64, request_term: u64) -> Result<()> {
+        self.raft.request_snapshot(request_index, request_term)
     }
 
     /// TransferLeader tries to transfer leadership to the given transferee.

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -743,10 +743,10 @@ impl<T: Storage> RawNode<T> {
     }
 
     /// Request a snapshot from a leader.
-    /// The snapshot's index must be greater or equal to the request_index.
-    /// The request_term is the term of request_index.
-    pub fn request_snapshot(&mut self, request_index: u64, request_term: u64) -> Result<()> {
-        self.raft.request_snapshot(request_index, request_term)
+    /// The snapshot's index must be greater or equal to the request_index (last_index) or
+    /// the leader's term must be greater than the request term (last_index's term).
+    pub fn request_snapshot(&mut self) -> Result<()> {
+        self.raft.request_snapshot()
     }
 
     /// TransferLeader tries to transfer leadership to the given transferee.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -538,7 +538,7 @@ mod test {
     }
 
     fn size_of<T: PbMessage>(m: &T) -> u32 {
-        m.compute_size() as u32
+        m.compute_size()
     }
 
     fn new_snapshot(index: u64, term: u64, voters: Vec<u64>) -> Snapshot {


### PR DESCRIPTION
### Change

Modify `request_snapshot` API, remove parameter: `request_index: u64`, use `last_index` as `request_index`, when sending request snapshot. 


### Reason

When a follower uses this interface to actively request a snapshot from the leader, it is not safe to pass an arbitrary index, as the leader will continue to send AppendRPC before receiving the snapshot request, this gap log follower is difficult to handle. Eg: it may panic at https://github.com/tikv/raft-rs/blob/5ce52b480065ff31ecef16b9b77c7c3b7c57c8c7/src/raw_node.rs#L520-L529. So the safest way is to use `last_index` as `request_index`, and the follower rejects `appendRPC`.

close tikv/raft-rs#498

Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>