### PR TITLE
Revoke pub from maybe_append

### DIFF
--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -239,14 +239,13 @@ impl<T: Storage> RaftLog<T> {
         self.term(idx).map(|t| t == term).unwrap_or(false)
     }
 
-    // TODO: revoke pub when there is a better way to append without proposals.
     /// Returns None if the entries cannot be appended. Otherwise,
     /// it returns Some((conflict_index, last_index)).
     ///
     /// # Panics
     ///
     /// Panics if it finds a conflicting index less than committed index.
-    pub fn maybe_append(
+    pub(crate) fn maybe_append(
         &mut self,
         idx: u64,
         term: u64,


### PR DESCRIPTION
This can be related to https://github.com/tikv/raft-rs/issues/35.

`pub(crate)` should be enough.

BTW, some methods are pub only for accessing in benches. I don't know if conditional export tech like below is worthy:

```rust
#[cfg(benches)]
pub fn bench_campaign(&mut self, campaign_type: &'static [u8]) {
  self.campaign(campaign_type)
}

fn campaign(&mut self, campaign_type: &'static [u8]) {
```

`#[cfg(benches)]` has no magic over a normal feature that we manually turn on when running benches.