### PR TITLE
chore: readability for take read state

### DIFF
--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -511,7 +511,7 @@ impl<T: Storage> RawNode<T> {
         }
 
         if !raft.read_states.is_empty() {
-            mem::swap(&mut rd.read_states, &mut raft.read_states);
+            rd.read_states = mem::take(&mut raft.read_states);
         }
 
         if let Some(snapshot) = &raft.raft_log.unstable_snapshot() {


### PR DESCRIPTION
It's more clear than `mem::swap` cause it doesn't depend on that `rd.read_state` happens to be empty.

Semantically we take the read state from node to ready, not swap.