### PR TITLE
chore: cfg test does not work for integration tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,9 +507,6 @@ mod config;
 mod errors;
 mod log_unstable;
 mod quorum;
-#[cfg(test)]
-pub mod raft;
-#[cfg(not(test))]
 mod raft;
 mod raft_log;
 pub mod raw_node;


### PR DESCRIPTION
We don't need this trick and all the code should work well.