### PR TITLE
Update LICENSE file to contain boilerplate project owner

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 TiKV Project Authors.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use super::read_only::{ReadOnlyOption, ReadState};
+pub use super::read_only::ReadOnlyOption;
 use super::util::NO_LIMIT;
 use super::{
     errors::{Error, Result},


### PR DESCRIPTION
As far as I understand the guidelines and looking at other projects (for example, Apache Kafka) the LICENSE file must contain boilerplate ("Copyright [yyyy] [name of copyright owner]") whereas other project files specific ("Copyright 2019 TiKV Project Authors").

Signed-off-by: Dzmitry Huba <huba@google.com>