### PR TITLE
Fix the compile error while running the cargo clippy

### DIFF
--- a/examples/single_mem_node/main.rs
+++ b/examples/single_mem_node/main.rs
@@ -6,7 +6,6 @@ use std::sync::mpsc::{self, RecvTimeoutError};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use raft::eraftpb::ConfState;
 use raft::prelude::*;
 use raft::storage::MemStorage;
 

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -5301,7 +5301,7 @@ fn test_election_with_priority_log() {
         (false, false, true, 1, 1, 3, 1, StateRole::Leader),
     ];
 
-    for (_i, &(l1, l2, l3, p1, p2, p3, id, state)) in tests.iter().enumerate() {
+    for &(l1, l2, l3, p1, p2, p3, id, state) in tests.iter() {
         let l = default_logger();
         let mut n1 = new_test_raft(1, vec![1, 2, 3], 10, 1, new_storage(), &l);
         let mut n2 = new_test_raft(2, vec![1, 2, 3], 10, 1, new_storage(), &l);

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -21,7 +21,7 @@ use std::panic::{self, AssertUnwindSafe};
 use harness::*;
 use protobuf::Message as PbMessage;
 use raft::eraftpb::*;
-use raft::storage::{GetEntriesContext, MemStorage};
+use raft::storage::MemStorage;
 use raft::*;
 use raft_proto::*;
 use slog::Logger;

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -17,7 +17,7 @@
 use harness::Network;
 use protobuf::{Message as PbMessage, ProtobufEnum as _};
 use raft::eraftpb::*;
-use raft::storage::{GetEntriesContext, MemStorage};
+use raft::storage::MemStorage;
 use raft::*;
 use raft_proto::*;
 use slog::Logger;

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -15,7 +15,6 @@
 // limitations under the License.
 
 use std::cmp;
-use std::convert::TryFrom;
 use std::ops::{Deref, DerefMut};
 
 use crate::eraftpb::{
@@ -24,8 +23,8 @@ use crate::eraftpb::{
 };
 use protobuf::Message as _;
 use raft_proto::ConfChangeI;
-use rand::{self, Rng};
-use slog::{self, Logger};
+use rand::Rng;
+use slog::Logger;
 
 #[cfg(feature = "failpoints")]
 use fail::fail_point;
@@ -285,9 +284,7 @@ impl<T: Storage> DerefMut for Raft<T> {
     }
 }
 
-trait AssertSend: Send {}
-
-impl<T: Storage + Send> AssertSend for Raft<T> {}
+impl<T: Storage + Send> Raft<T> {}
 
 fn new_message(to: u64, field_type: MessageType, from: Option<u64>) -> Message {
     let mut m = Message::default();

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -1084,7 +1084,7 @@ mod test {
     fn test_unstable_ents() {
         let l = default_logger();
         let previous_ents = vec![new_entry(1, 1), new_entry(2, 2)];
-        let tests = vec![(3, vec![]), (1, previous_ents.clone())];
+        let tests = [(3, vec![]), (1, previous_ents.clone())];
 
         for (i, &(unstable, ref wents)) in tests.iter().enumerate() {
             // append stable entries to storage
@@ -1668,7 +1668,7 @@ mod test {
     #[test]
     fn test_compaction() {
         let l = default_logger();
-        let tests = vec![
+        let tests = [
             // out of upper bound
             (1000, vec![1001u64], vec![0usize], true),
             (


### PR DESCRIPTION
I ran the instruction `cargo clippy --all --all-targets -- -D clippy::all` according to the README and got below error:

```
❯ cargo clippy --all --all-targets -- -D clippy::all
    Checking harness v0.1.0 (/Users/hulk/code/rust/raft-rs/harness)
error: you seem to use `.enumerate()` and immediately discard the index
    --> harness/tests/integration_cases/test_raft.rs:5304:54
     |
5304 |     for (_, &(l1, l2, l3, p1, p2, p3, id, state)) in tests.iter().enumerate() {
     |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unused_enumerate_index
     = note: `-D clippy::unused-enumerate-index` implied by `-D clippy::all`
     = help: to override `-D clippy::all` add `#[allow(clippy::unused_enumerate_index)]`
help: remove the `.enumerate()` call
     |
5304 |     for &(l1, l2, l3, p1, p2, p3, id, state) in tests.iter() {
     |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~    ~~~~~~~~~~~~

```