### PR TITLE
remove deprecated feature "cargo-clippy"

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,7 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 #![allow(dead_code)] // Due to criterion we need this to avoid warnings.
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::let_and_return))] // Benches often artificially return values. Allow it.
 
 use criterion::Criterion;
 use std::time::Duration;

--- a/harness/tests/tests.rs
+++ b/harness/tests/tests.rs
@@ -1,6 +1,5 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-#![cfg_attr(not(feature = "cargo-clippy"), allow(unknown_lints))]
 #![cfg_attr(feature = "failpoints", allow(dead_code, unused_imports))]
 // We use `default` method a lot to be support prost and rust-protobuf at the
 // same time. And reassignment can be optimized by compiler.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,7 +50,6 @@ pub enum Error {
 }
 
 impl PartialEq for Error {
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::match_same_arms))]
     fn eq(&self, other: &Error) -> bool {
         match (self, other) {
             (Error::StepPeerNotFound, Error::StepPeerNotFound) => true,
@@ -90,7 +89,6 @@ pub enum StorageError {
 }
 
 impl PartialEq for StorageError {
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::match_same_arms))]
     fn eq(&self, other: &StorageError) -> bool {
         matches!(
             (self, other),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,7 +475,6 @@ before taking old, removed peers offline.
 
 */
 
-#![cfg_attr(not(feature = "cargo-clippy"), allow(unknown_lints))]
 #![deny(clippy::all)]
 #![deny(missing_docs)]
 #![recursion_limit = "128"]

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -922,7 +922,6 @@ impl<T: Storage> Raft<T> {
         self.bcast_heartbeat_with_ctx(ctx)
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::needless_pass_by_value))]
     fn bcast_heartbeat_with_ctx(&mut self, ctx: Option<Vec<u8>>) {
         let self_id = self.id;
         let core = &mut self.r;

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -374,7 +374,6 @@ impl<T: Storage> RawNode<T> {
     /// If the node enters joint state with `auto_leave` set to true, it's
     /// caller's responsibility to propose an empty conf change again to force
     /// leaving joint state.
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::needless_pass_by_value))]
     pub fn propose_conf_change(&mut self, context: Vec<u8>, cc: impl ConfChangeI) -> Result<()> {
         let (data, ty) = if let Some(cc) = cc.as_v1() {
             (cc.write_to_bytes()?, EntryType::EntryConfChange)


### PR DESCRIPTION
the build-in feature `cargo-clippy` is deprecated recently. See: https://blog.rust-lang.org/2024/02/28/Clippy-deprecating-feature-cargo-clippy.html

Remove this already useless feature to make nightly build pass.