### PR TITLE
reset max_apply_unpersisted_log_limit in become_follower

### DIFF
--- a/examples/five_mem_node/main.rs
+++ b/examples/five_mem_node/main.rs
@@ -278,6 +278,7 @@ fn on_ready(
         }
     }
 
+    let reg = Regex::new("put ([0-9]+) (.+)").unwrap();
     let mut handle_committed_entries =
         |rn: &mut RawNode<MemStorage>, committed_entries: Vec<Entry>| {
             for entry in committed_entries {
@@ -295,7 +296,6 @@ fn on_ready(
                     // For normal proposals, extract the key-value pair and then
                     // insert them into the kv engine.
                     let data = str::from_utf8(&entry.data).unwrap();
-                    let reg = Regex::new("put ([0-9]+) (.+)").unwrap();
                     if let Some(caps) = reg.captures(data) {
                         kv_pairs.insert(caps[1].parse().unwrap(), caps[2].to_string());
                     }

--- a/harness/src/network.rs
+++ b/harness/src/network.rs
@@ -186,7 +186,7 @@ impl Network {
     ///
     /// Unlike `send` this does not gather and send any responses. It also does not ignore errors.
     pub fn dispatch(&mut self, messages: impl IntoIterator<Item = Message>) -> Result<()> {
-        for message in self.filter(messages.into_iter().map(Into::into)) {
+        for message in self.filter(messages.into_iter()) {
             let to = message.to;
             let peer = self.peers.get_mut(&to).unwrap();
             peer.step(message)?;

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -1882,6 +1882,9 @@ fn test_leader_stepdown_when_quorum_lost() {
 
     assert_eq!(sm.state, StateRole::Follower);
     // check after become follower, the limit is reset.
+    // Currently we only support return committed but not persisted raft
+    // entries on raft leader. Due to the limitation of current interface,
+    // we hard code this logic in raft-rs.
     assert_eq!(sm.raft_log.max_apply_unpersisted_log_limit, 0);
 }
 

--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -1874,12 +1874,15 @@ fn test_leader_stepdown_when_quorum_lost() {
 
     sm.become_candidate();
     sm.become_leader();
+    sm.raft_log.max_apply_unpersisted_log_limit = 100;
 
     for _ in 0..=sm.election_timeout() {
         sm.tick();
     }
 
     assert_eq!(sm.state, StateRole::Follower);
+    // check after become follower, the limit is reset.
+    assert_eq!(sm.raft_log.max_apply_unpersisted_log_limit, 0);
 }
 
 #[test]

--- a/harness/tests/integration_cases/test_raw_node.rs
+++ b/harness/tests/integration_cases/test_raw_node.rs
@@ -276,7 +276,7 @@ fn test_raw_node_propose_and_conf_change() {
                     }
                 };
             handle_committed_entries(&mut raw_node, rd.take_committed_entries());
-            let is_leader = rd.ss().map_or(false, |ss| ss.leader_id == raw_node.raft.id);
+            let is_leader = rd.ss().is_some_and(|ss| ss.leader_id == raw_node.raft.id);
 
             let mut light_rd = raw_node.advance(rd);
             handle_committed_entries(&mut raw_node, light_rd.take_committed_entries());
@@ -408,7 +408,7 @@ fn test_raw_node_joint_auto_leave() {
                 }
             };
         handle_committed_entries(&mut raw_node, rd.take_committed_entries());
-        let is_leader = rd.ss().map_or(false, |ss| ss.leader_id == raw_node.raft.id);
+        let is_leader = rd.ss().is_some_and(|ss| ss.leader_id == raw_node.raft.id);
 
         let mut light_rd = raw_node.advance(rd);
         handle_committed_entries(&mut raw_node, light_rd.take_committed_entries());
@@ -486,7 +486,7 @@ fn test_raw_node_propose_add_duplicate_node() {
     loop {
         let rd = raw_node.ready();
         s.wl().append(rd.entries()).unwrap();
-        if rd.ss().map_or(false, |ss| ss.leader_id == raw_node.raft.id) {
+        if rd.ss().is_some_and(|ss| ss.leader_id == raw_node.raft.id) {
             let _ = raw_node.advance(rd);
             break;
         }
@@ -555,7 +555,7 @@ fn test_raw_node_propose_add_learner_node() -> Result<()> {
     loop {
         let rd = raw_node.ready();
         s.wl().append(rd.entries()).unwrap();
-        if rd.ss().map_or(false, |ss| ss.leader_id == raw_node.raft.id) {
+        if rd.ss().is_some_and(|ss| ss.leader_id == raw_node.raft.id) {
             let _ = raw_node.advance(rd);
             break;
         }
@@ -605,7 +605,7 @@ fn test_raw_node_read_index() {
     loop {
         let rd = raw_node.ready();
         s.wl().append(rd.entries()).unwrap();
-        if rd.ss().map_or(false, |ss| ss.leader_id == raw_node.raft.id) {
+        if rd.ss().is_some_and(|ss| ss.leader_id == raw_node.raft.id) {
             let _ = raw_node.advance(rd);
 
             // Once we are the leader, issue a read index request
@@ -839,7 +839,7 @@ fn test_bounded_uncommitted_entries_growth_with_partition() {
         s.wl().append(rd.entries()).unwrap();
         if rd
             .ss()
-            .map_or(false, |ss| ss.leader_id == raw_node.raft.leader_id)
+            .is_some_and(|ss| ss.leader_id == raw_node.raft.leader_id)
         {
             let _ = raw_node.advance(rd);
             break;
@@ -1052,7 +1052,7 @@ fn test_raw_node_with_async_apply() {
     // Single node should become leader.
     assert!(rd
         .ss()
-        .map_or(false, |ss| ss.leader_id == raw_node.raft.leader_id));
+        .is_some_and(|ss| ss.leader_id == raw_node.raft.leader_id));
     s.wl().append(rd.entries()).unwrap();
     let _ = raw_node.advance(rd);
 
@@ -1277,7 +1277,7 @@ fn test_async_ready_leader() {
     let rd = raw_node.ready();
     assert!(rd
         .ss()
-        .map_or(false, |ss| ss.leader_id == raw_node.raft.leader_id));
+        .is_some_and(|ss| ss.leader_id == raw_node.raft.leader_id));
     s.wl().append(rd.entries()).unwrap();
     let _ = raw_node.advance(rd);
 

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -824,7 +824,7 @@ impl<T: Storage> RaftCore<T> {
                     aggressively: !allow_empty,
                 }),
             );
-            if !allow_empty && ents.as_ref().ok().map_or(true, |e| e.is_empty()) {
+            if !allow_empty && ents.as_ref().map_or(true, |e| e.is_empty()) {
                 return false;
             }
             let term = self.raft_log.term(pr.next_idx - 1);

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1152,6 +1152,12 @@ impl<T: Storage> Raft<T> {
         let from_role = self.state;
         self.state = StateRole::Follower;
         self.pending_request_snapshot = pending_request_snapshot;
+        // TODO: In theory, we should better control this in the caller,
+        // but bacuase the caller only know the leadership changes after
+        // call `ready()` and the committed entries is fetched within `ready()`,
+        // so we hard code this logic here. We may need to remove this hard code
+        // when we want to also support apply unpersisted log on follower.
+        self.raft_log.max_apply_unpersisted_log_limit = 0;
         info!(
             self.logger,
             "became follower at term {term}",

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -583,14 +583,14 @@ impl<T: Storage> Raft<T> {
     pub fn commit_to_current_term(&self) -> bool {
         self.raft_log
             .term(self.raft_log.committed)
-            .map_or(false, |t| t == self.term)
+            .is_ok_and(|t| t == self.term)
     }
 
     /// Checks if logs are applied to current term.
     pub fn apply_to_current_term(&self) -> bool {
         self.raft_log
             .term(self.raft_log.applied)
-            .map_or(false, |t| t == self.term)
+            .is_ok_and(|t| t == self.term)
     }
 
     /// Set `max_committed_size_per_ready` to `size`.
@@ -2753,7 +2753,7 @@ impl<T: Storage> Raft<T> {
                 .r
                 .read_only
                 .recv_ack(self.id, &ctx)
-                .map_or(false, |acks| prs.has_quorum(acks))
+                .is_some_and(|acks| prs.has_quorum(acks))
             {
                 for rs in self.r.read_only.advance(&ctx, &self.r.logger) {
                     if let Some(m) = self.handle_ready_read_index(rs.req, rs.index) {
@@ -2765,7 +2765,7 @@ impl<T: Storage> Raft<T> {
 
         if self
             .lead_transferee
-            .map_or(false, |e| !self.prs.conf().voters.contains(e))
+            .is_some_and(|e| !self.prs.conf().voters.contains(e))
         {
             self.abort_leader_transfer();
         }

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -1152,11 +1152,12 @@ impl<T: Storage> Raft<T> {
         let from_role = self.state;
         self.state = StateRole::Follower;
         self.pending_request_snapshot = pending_request_snapshot;
-        // TODO: In theory, we should better control this in the caller,
-        // but bacuase the caller only know the leadership changes after
-        // call `ready()` and the committed entries is fetched within `ready()`,
-        // so we hard code this logic here. We may need to remove this hard code
-        // when we want to also support apply unpersisted log on follower.
+        // TODO: In theory, it's better to let the user control this after
+        // leadership changes, but bacuase the user only know this info after
+        // call `ready()` but the committed entries is fetched within `ready()`,
+        // so we hard code this logic here currently. We may need to remove
+        // this hard code when we want to also support apply unpersisted log
+        // on follower.
         self.raft_log.max_apply_unpersisted_log_limit = 0;
         info!(
             self.logger,

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -65,6 +65,10 @@ pub struct RaftLog<T: Storage> {
     pub applied: u64,
 
     /// The maximum log gap between persisted and applied.
+    ///
+    /// NOTE: We force reset `max_apply_unpersisted_log_limit` value to 0 when
+    /// raft role demote from leader currently to ensure only allow applying
+    /// not persisted raft logs on leader.
     pub max_apply_unpersisted_log_limit: u64,
 }
 

--- a/src/raft_log.rs
+++ b/src/raft_log.rs
@@ -519,7 +519,7 @@ impl<T: Storage> RaftLog<T> {
 
     /// Attempts to commit the index and term and returns whether it did.
     pub fn maybe_commit(&mut self, max_index: u64, term: u64) -> bool {
-        if max_index > self.committed && self.term(max_index).map_or(false, |t| t == term) {
+        if max_index > self.committed && self.term(max_index).is_ok_and(|t| t == term) {
             debug!(
                 self.unstable.logger,
                 "committing index {index}",
@@ -554,7 +554,7 @@ impl<T: Storage> RaftLog<T> {
         };
         if index > self.persisted
             && index < first_update_index
-            && self.store.term(index).map_or(false, |t| t == term)
+            && self.store.term(index).is_ok_and(|t| t == term)
         {
             debug!(self.unstable.logger, "persisted index {}", index);
             self.persisted = index;

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -571,7 +571,7 @@ impl<T: Storage> RawNode<T> {
             return true;
         }
 
-        if self.snap().map_or(false, |s| !s.is_empty()) {
+        if self.snap().is_some_and(|s| !s.is_empty()) {
             return true;
         }
 

--- a/src/tracker/inflights.rs
+++ b/src/tracker/inflights.rs
@@ -85,7 +85,7 @@ impl Inflights {
     /// Returns true if the inflights is full.
     #[inline]
     pub fn full(&self) -> bool {
-        self.count == self.cap || self.incoming_cap.map_or(false, |cap| self.count >= cap)
+        self.count == self.cap || self.incoming_cap.is_some_and(|cap| self.count >= cap)
     }
 
     /// Adds an inflight into inflights


### PR DESCRIPTION
This PR reset the `max_apply_unpersisted_log_limit` value when peer role demote from leader to follower. Because the user can only notice role change event after call `ready()` and the committed entries are collected in the `ready()` so we have to do this here to ensure we only enable `max_apply_unpersisted_log_limit` on raft leader. 

NOTE: In theory, the affect of `max_apply_unpersisted_log_limit` is not related the raft role. We limit it to only leader to prevent potencial corn cases. We may want to remove this restriction in the future. In that case, we should revert this PR then.

See https://github.com/tikv/tikv/issues/17868 for more details.