### PR TITLE
extend commit group to learners

### DIFF
--- a/harness/tests/integration_cases/test_raft.rs
+++ b/harness/tests/integration_cases/test_raft.rs
@@ -5165,6 +5165,252 @@ fn test_group_commit() {
 }
 
 #[test]
+fn test_group_commit_for_learner() {
+    let l = default_logger();
+    // Test cases: (
+    //      leader_matches,
+    //      follower_matches,
+    //      learner_matches,
+    //      leader_follower_learner_group_ids,
+    //      expected_commit_with_group,
+    //      expected_commit_without_group
+    // )
+    let mut tests = vec![
+        // Single learner cases
+        (vec![3], vec![], vec![2], vec![1, 1], 3, 3),
+        // If learner has different group, we still need to wait for the other group's ACK
+        (vec![3], vec![], vec![2], vec![1, 2], 2, 3),
+        // and group_id 0 means no group commit. It also blocks the progress when there's no the second group
+        (vec![3], vec![], vec![2], vec![1, 0], 2, 3),
+        // Below cases test multiple learners
+        (vec![4], vec![], vec![2, 3], vec![1, 1, 1], 4, 4),
+        (vec![4], vec![], vec![3, 1], vec![1, 1, 2], 1, 4),
+        (vec![4], vec![], vec![2, 3], vec![1, 1, 2], 3, 4),
+        // Below two cases test that if there exists the second group, group ID 0 can be ignored.
+        // Because at least we have replicated to 2 groups.
+        (vec![4], vec![], vec![3, 2], vec![1, 0, 2], 2, 4),
+        (vec![4], vec![], vec![3, 2], vec![1, 2, 0], 3, 4),
+        // Test more learners
+        (vec![10], vec![], vec![2, 3, 4], vec![1, 1, 2, 0], 3, 10),
+        (vec![10], vec![], vec![2, 3, 4], vec![1, 1, 2, 2], 4, 10),
+        (vec![10], vec![], vec![2, 3, 4], vec![1, 2, 0, 0], 2, 10),
+        (vec![10], vec![], vec![2, 3, 4], vec![1, 2, 3, 4], 4, 10),
+        (vec![10], vec![], vec![2, 3, 4], vec![1, 2, 3, 1], 3, 10),
+        (vec![10], vec![], vec![2, 3, 4], vec![1, 2, 1, 1], 2, 10),
+        // With followers
+        (vec![5], vec![2, 4], vec![3], vec![1, 1, 1, 1], 4, 4),
+        (vec![5], vec![2, 4], vec![3], vec![1, 1, 1, 2], 3, 4),
+        (vec![5], vec![2, 4], vec![3], vec![1, 1, 2, 2], 4, 4),
+        (vec![5], vec![2, 4], vec![3], vec![1, 1, 2, 1], 4, 4),
+        (vec![5], vec![2, 4], vec![3], vec![1, 1, 2, 0], 4, 4),
+        // Multiple followers and learners. Only 1 learner in the 2nd group and it will lower down the index
+        (
+            vec![6],
+            vec![4, 5],
+            vec![2, 3, 4],
+            vec![1, 1, 1, 1, 1, 2],
+            4,
+            5,
+        ),
+        (
+            vec![6],
+            vec![4, 5],
+            vec![2, 3, 4],
+            vec![1, 1, 1, 1, 2, 1],
+            3,
+            5,
+        ),
+        (
+            vec![6],
+            vec![4, 5],
+            vec![2, 3, 4],
+            vec![1, 1, 1, 2, 0, 1],
+            2,
+            5,
+        ),
+        // Multiple followers and learners. Only 1 follower in the 2nd group and it will lower down the index
+        (
+            vec![6],
+            vec![4, 5],
+            vec![2, 3, 4],
+            vec![1, 2, 1, 1, 1, 1],
+            4,
+            5,
+        ),
+        (
+            vec![6],
+            vec![4, 5],
+            vec![2, 3, 4],
+            vec![1, 1, 2, 1, 1, 1],
+            5,
+            5,
+        ),
+        // Multiple followers and learners. The 2nd group has multiple learners / followers / leader
+        (
+            vec![6],
+            vec![4, 5],
+            vec![2, 3, 4],
+            vec![1, 1, 2, 1, 2, 2],
+            5,
+            5,
+        ),
+        (
+            vec![6],
+            vec![4, 5],
+            vec![2, 3, 4],
+            vec![1, 2, 1, 2, 1, 1],
+            4,
+            5,
+        ),
+        (
+            vec![6],
+            vec![4, 5],
+            vec![2, 3, 4],
+            vec![2, 1, 1, 2, 2, 2],
+            5,
+            5,
+        ),
+        // learners are faster than followers, quorum index is used
+        (
+            vec![100],
+            vec![10, 10, 5],
+            vec![100],
+            vec![1, 1, 1, 2, 2],
+            10,
+            10,
+        ),
+        // long test case
+        (
+            vec![100],
+            vec![10, 10, 5, 10, 10, 10, 10, 5, 5],
+            vec![1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            vec![1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
+            1,
+            10,
+        ),
+        (
+            vec![100],
+            vec![10, 10, 5, 10, 10, 10, 10, 5, 5],
+            vec![1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            vec![2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2],
+            10,
+            10,
+        ),
+        (
+            vec![100],
+            vec![10, 10, 5, 10, 10, 10, 10, 5, 5],
+            vec![20, 20, 20, 20, 20, 20, 20, 20, 20, 20],
+            vec![1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2],
+            10,
+            10,
+        ),
+        (
+            vec![100],
+            vec![10, 10, 5, 10, 10, 10, 10, 5, 5],
+            vec![20, 20, 20, 20, 20, 20, 20, 20, 20, 20],
+            vec![1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2],
+            10,
+            10,
+        ),
+    ];
+
+    for (
+        i,
+        (
+            leader_matches,
+            follower_matches,
+            learner_matches,
+            leader_follower_learner_group_ids,
+            g_w,
+            q_w,
+        ),
+    ) in tests.drain(..).enumerate()
+    {
+        let store = MemStorage::new_with_conf_state((vec![1], vec![]));
+        let max_index = *leader_matches.iter().max().unwrap();
+        let logs: Vec<_> = (1..=max_index).map(|i| empty_entry(1, i)).collect();
+        store.wl().append(&logs).unwrap();
+        let mut hs = HardState::default();
+        hs.term = 1;
+        store.wl().set_hardstate(hs);
+        let cfg = new_test_config(1, 5, 1);
+        let mut sm = new_test_raft_with_config(&cfg, store, &l);
+        let mut groups = vec![];
+        if leader_follower_learner_group_ids[0] != 0 {
+            groups.push((1, leader_follower_learner_group_ids[0])); // leader
+        }
+
+        // Add followers as voters
+        let mut next_id = 2u64;
+        for &matched in &follower_matches {
+            sm.apply_conf_change(&add_node(next_id)).unwrap();
+            let pr = sm.mut_prs().get_mut(next_id).unwrap();
+            pr.matched = matched;
+            pr.next_idx = matched + 1;
+            if leader_follower_learner_group_ids[next_id as usize - 1] != 0 {
+                groups.push((
+                    next_id,
+                    leader_follower_learner_group_ids[next_id as usize - 1],
+                ));
+            }
+            next_id += 1;
+        }
+
+        // Add learners
+        for &matched in &learner_matches {
+            sm.apply_conf_change(&add_learner(next_id)).unwrap();
+            let pr = sm.mut_prs().get_mut(next_id).unwrap();
+            pr.matched = matched;
+            pr.next_idx = matched + 1;
+            if leader_follower_learner_group_ids[next_id as usize - 1] != 0 {
+                groups.push((
+                    next_id,
+                    leader_follower_learner_group_ids[next_id as usize - 1],
+                ));
+            }
+            next_id += 1;
+        }
+
+        // Set leader's matched index
+        if let Some(&leader_matched) = leader_matches.first() {
+            let pr = sm.mut_prs().get_mut(1).unwrap();
+            pr.matched = leader_matched;
+            pr.next_idx = leader_matched + 1;
+        }
+
+        // Test as follower first (should not commit with group rules)
+        sm.enable_group_commit_for_learner(true);
+        sm.assign_commit_groups(&groups);
+        if sm.raft_log.committed != 0 {
+            panic!(
+                "#{}: follower group committed {}, want 0",
+                i, sm.raft_log.committed
+            );
+        }
+
+        // Become leader and test group commit
+        sm.state = StateRole::Leader;
+        sm.assign_commit_groups(&groups);
+        if sm.raft_log.committed != g_w {
+            panic!(
+                "#{}: leader group committed {}, want {}",
+                i, sm.raft_log.committed, g_w
+            );
+        }
+
+        // Disable group commit and test normal quorum
+        sm.enable_group_commit_for_learner(false);
+        sm.enable_group_commit(false);
+        if sm.raft_log.committed != q_w {
+            panic!(
+                "#{}: quorum committed {}, want {}",
+                i, sm.raft_log.committed, q_w
+            );
+        }
+    }
+}
+
+#[test]
 fn test_group_commit_consistent() {
     let l = default_logger();
     let mut logs = vec![];

--- a/src/quorum/datadriven_test.rs
+++ b/src/quorum/datadriven_test.rs
@@ -173,28 +173,31 @@ fn test_quorum(data: &TestData) -> String {
             if joint {
                 let cc = JointConfig::new_joint_from_majorities(c.clone(), cj.clone());
                 buf.push_str(&cc.describe(&l));
-                idx = cc.committed_index(use_group_commit, &l);
+                idx = cc.committed_index(use_group_commit, &l, &[]);
                 // Interchanging the majorities shouldn't make a difference. If it does, print.
-                let a_idx = JointConfig::new_joint_from_majorities(cj, c)
-                    .committed_index(use_group_commit, &l);
+                let a_idx = JointConfig::new_joint_from_majorities(cj, c).committed_index(
+                    use_group_commit,
+                    &l,
+                    &[],
+                );
                 if a_idx != idx {
                     writeln!(buf, "{} <-- via symmetry", a_idx.0).unwrap();
                 }
             } else {
-                idx = c.committed_index(use_group_commit, &l);
+                idx = c.committed_index(use_group_commit, &l, &[]);
                 buf.push_str(&c.describe(&l));
 
                 // Joining a majority with the empty majority should give same result.
                 let a_idx =
                     JointConfig::new_joint_from_majorities(c.clone(), MajorityConfig::default())
-                        .committed_index(use_group_commit, &l);
+                        .committed_index(use_group_commit, &l, &[]);
                 if a_idx != idx {
                     writeln!(buf, "{} <-- via zero-joint quorum", a_idx.0).unwrap();
                 }
 
                 // Joining a majority with itself should give same result.
                 let a_idx = JointConfig::new_joint_from_majorities(c.clone(), c.clone())
-                    .committed_index(use_group_commit, &l);
+                    .committed_index(use_group_commit, &l, &[]);
                 if a_idx != idx {
                     writeln!(buf, "{} <-- via self-joint quorum", a_idx.0).unwrap();
                 }
@@ -214,7 +217,7 @@ fn test_quorum(data: &TestData) -> String {
                                 },
                             );
 
-                            let a_idx = c.committed_index(use_group_commit, &l);
+                            let a_idx = c.committed_index(use_group_commit, &l, &[]);
                             if a_idx != idx {
                                 writeln!(
                                     buf,
@@ -234,7 +237,7 @@ fn test_quorum(data: &TestData) -> String {
                                 },
                             );
 
-                            let a_idx = c.committed_index(use_group_commit, &l);
+                            let a_idx = c.committed_index(use_group_commit, &l, &[]);
                             if a_idx != idx {
                                 writeln!(buf, "{} <-- overlaying {}->{}", a_idx.0, id, 0).unwrap();
                             }
@@ -265,10 +268,13 @@ fn test_quorum(data: &TestData) -> String {
                 let cc = JointConfig::new_joint_from_majorities(c.clone(), cj.clone());
                 // `describe` doesn't seem to be useful for group commit.
                 // buf.push_str(&cc.describe(&l));
-                idx = cc.committed_index(use_group_commit, &l);
+                idx = cc.committed_index(use_group_commit, &l, &[]);
                 // Interchanging the majorities shouldn't make a difference. If it does, print.
-                let a_idx = JointConfig::new_joint_from_majorities(cj, c)
-                    .committed_index(use_group_commit, &l);
+                let a_idx = JointConfig::new_joint_from_majorities(cj, c).committed_index(
+                    use_group_commit,
+                    &l,
+                    &[],
+                );
                 if a_idx != idx {
                     writeln!(buf, "{} <-- via symmetry", a_idx.0).unwrap();
                 }

--- a/src/quorum/joint.rs
+++ b/src/quorum/joint.rs
@@ -1,6 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-use super::{AckedIndexer, VoteResult};
+use super::{AckedIndexer, Index, VoteResult};
 use crate::util::Union;
 use crate::HashSet;
 use crate::MajorityConfig;
@@ -42,11 +42,22 @@ impl Configuration {
     /// Returns the largest committed index for the given joint quorum. An index is
     /// jointly committed if it is committed in both constituent majorities.
     ///
+    /// `learner_indexes` is a list of indexes for learners when enable_group_commit_for_learner.
+    ///
     /// The bool flag indicates whether the index is computed by group commit algorithm
     /// successfully. It's true only when both majorities use group commit.
-    pub fn committed_index(&self, use_group_commit: bool, l: &impl AckedIndexer) -> (u64, bool) {
-        let (i_idx, i_use_gc) = self.incoming.committed_index(use_group_commit, l);
-        let (o_idx, o_use_gc) = self.outgoing.committed_index(use_group_commit, l);
+    pub fn committed_index(
+        &self,
+        use_group_commit: bool,
+        l: &impl AckedIndexer,
+        learner_indexes: &[Index],
+    ) -> (u64, bool) {
+        let (i_idx, i_use_gc) = self
+            .incoming
+            .committed_index(use_group_commit, l, learner_indexes);
+        let (o_idx, o_use_gc) = self
+            .outgoing
+            .committed_index(use_group_commit, l, learner_indexes);
         (cmp::min(i_idx, o_idx), i_use_gc && o_use_gc)
     }
 

--- a/src/quorum/majority.rs
+++ b/src/quorum/majority.rs
@@ -62,12 +62,19 @@ impl Configuration {
     /// Computes the committed index from those supplied via the
     /// provided AckedIndexer (for the active config).
     ///
+    /// `learner_indexes` is a list of indexes for learners when enable_group_commit_for_learner.
+    ///
     /// The bool flag indicates whether the index is computed by group commit algorithm
     /// successfully.
     ///
     /// Eg. If the matched indexes are `[2,2,2,4,5]`, it will return `2`.
     /// If the matched indexes and groups are `[(1, 1), (2, 2), (3, 2)]`, it will return `1`.
-    pub fn committed_index(&self, use_group_commit: bool, l: &impl AckedIndexer) -> (u64, bool) {
+    pub fn committed_index(
+        &self,
+        use_group_commit: bool,
+        l: &impl AckedIndexer,
+        learner_indexes: &[Index],
+    ) -> (u64, bool) {
         if self.voters.is_empty() {
             // This plays well with joint quorums which, when one half is the zero
             // MajorityConfig, should behave like the other half.
@@ -76,7 +83,7 @@ impl Configuration {
 
         let mut stack_arr: [MaybeUninit<Index>; 7] = unsafe { MaybeUninit::uninit().assume_init() };
         let mut heap_arr;
-        let matched = if self.voters.len() <= 7 {
+        let mut matched = if self.voters.len() <= 7 {
             for (i, v) in self.voters.iter().enumerate() {
                 stack_arr[i] = MaybeUninit::new(l.acked_index(*v).unwrap_or_default());
             }
@@ -88,8 +95,8 @@ impl Configuration {
             for v in &self.voters {
                 buf.push(l.acked_index(*v).unwrap_or_default());
             }
-            heap_arr = Some(buf);
-            heap_arr.as_mut().unwrap().as_mut_slice()
+            heap_arr = buf;
+            heap_arr.as_mut_slice()
         };
         // Reverse sort.
         matched.sort_by(|a, b| b.index.cmp(&a.index));
@@ -99,8 +106,27 @@ impl Configuration {
         if !use_group_commit {
             return (quorum_index.index, false);
         }
+
         let (quorum_commit_index, mut checked_group_id) =
             (quorum_index.index, quorum_index.group_id);
+
+        if !learner_indexes.is_empty() {
+            let new_len = self.voters.len() + learner_indexes.len();
+            matched = if new_len <= 7 {
+                for (i, idx) in learner_indexes.iter().enumerate() {
+                    stack_arr[i + self.voters.len()] = MaybeUninit::new(*idx);
+                }
+                unsafe { slice::from_raw_parts_mut(stack_arr.as_mut_ptr() as *mut Index, new_len) }
+            } else {
+                let mut buf = Vec::with_capacity(new_len);
+                buf.extend_from_slice(matched);
+                buf.extend_from_slice(learner_indexes);
+                heap_arr = buf;
+                heap_arr.as_mut_slice()
+            };
+            matched.sort_by(|a, b| b.index.cmp(&a.index));
+        }
+
         let mut single_group = true;
         for m in matched.iter() {
             if m.group_id == 0 {
@@ -117,8 +143,10 @@ impl Configuration {
             return (cmp::min(m.index, quorum_commit_index), true);
         }
         if single_group {
+            // all peers belong to the same group, still use quorum
             (quorum_commit_index, false)
         } else {
+            // Some peers have set group ID, but we can't find the second group and there are ungrouped peers
             (matched.last().unwrap().index, false)
         }
     }

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -506,14 +506,30 @@ impl<T: Storage> Raft<T> {
         self.batch_append = batch_append;
     }
 
-    /// Configures group commit.
+    /// Configures group commit. It also calls `enable_group_commit_for_learner`
+    /// to turn off internally if necessary.
     ///
     /// If group commit is enabled, only logs replicated to at least two
     /// different groups are committed.
     ///
-    /// You should use `assign_commit_groups` to configure peer groups.
+    /// You MUST use `assign_commit_groups` to configure peer groups.
     pub fn enable_group_commit(&mut self, enable: bool) {
         self.mut_prs().enable_group_commit(enable);
+        if StateRole::Leader == self.state && !enable && self.maybe_commit() {
+            self.bcast_append();
+        }
+    }
+
+    /// Configures group commit for learner. It also calls `enable_group_commit`
+    /// to turn on internally if necessary.
+    ///
+    /// After calculates committed index based on voters, it further makes sure
+    /// log should be replicated to at least two groups of voters+learners if the
+    /// group number of voters+learners is larger than 1.
+    ///
+    /// You MUST use `assign_commit_groups` to configure peer groups.
+    pub fn enable_group_commit_for_learner(&mut self, enable: bool) {
+        self.mut_prs().enable_group_commit_for_learner(enable);
         if StateRole::Leader == self.state && !enable && self.maybe_commit() {
             self.bcast_append();
         }

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -28,6 +28,8 @@ use crate::quorum::{AckedIndexer, Index, VoteResult};
 use crate::{DefaultHashBuilder, HashMap, HashSet, JointConfig};
 use getset::Getters;
 use std::fmt::Debug;
+use std::mem::MaybeUninit;
+use std::slice;
 
 /// Config reflects the configuration tracked in a ProgressTracker.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Getters)]
@@ -202,6 +204,7 @@ pub struct ProgressTracker {
     max_inflight: usize,
 
     group_commit: bool,
+    group_commit_for_learner: bool,
 }
 
 impl ProgressTracker {
@@ -221,12 +224,24 @@ impl ProgressTracker {
             votes: HashMap::with_capacity_and_hasher(voters, DefaultHashBuilder::default()),
             max_inflight,
             group_commit: false,
+            group_commit_for_learner: false,
         }
     }
 
     /// Configures group commit.
     pub fn enable_group_commit(&mut self, enable: bool) {
         self.group_commit = enable;
+        if !enable && self.group_commit_for_learner {
+            self.group_commit_for_learner = false;
+        }
+    }
+
+    /// Configures group commit for learner mode.
+    pub fn enable_group_commit_for_learner(&mut self, enable: bool) {
+        if enable && !self.group_commit {
+            self.group_commit = true;
+        }
+        self.group_commit_for_learner = enable;
     }
 
     /// Whether enable group commit.
@@ -282,9 +297,36 @@ impl ProgressTracker {
     /// Eg. If the matched indexes are `[2,2,2,4,5]`, it will return `2`.
     /// If the matched indexes and groups are `[(1, 1), (2, 2), (3, 2)]`, it will return `1`.
     pub fn maximal_committed_index(&mut self) -> (u64, bool) {
+        let mut stack_arr: [MaybeUninit<Index>; 7] = unsafe { MaybeUninit::uninit().assume_init() };
+        let heap_arr;
+
+        let learner_indexes = if !self.group_commit_for_learner {
+            &[]
+        } else {
+            let learner_index_iter = self
+                .conf
+                .learners
+                .union(&self.conf.learners_next)
+                .filter_map(|id| self.progress.acked_index(*id));
+            let learner_size = self.conf.learners.len() + self.conf.learners_next.len();
+
+            if learner_size <= 7 {
+                // due to filter_map, actual_size is less than or equal to learner_size.
+                let mut actual_size = 0;
+                for (i, idx) in learner_index_iter.enumerate() {
+                    stack_arr[i] = MaybeUninit::new(idx);
+                    actual_size += 1;
+                }
+                unsafe { slice::from_raw_parts(stack_arr.as_mut_ptr() as *mut _, actual_size) }
+            } else {
+                heap_arr = learner_index_iter.collect::<Vec<_>>();
+                heap_arr.as_slice()
+            }
+        };
+
         self.conf
             .voters
-            .committed_index(self.group_commit, &self.progress)
+            .committed_index(self.group_commit, &self.progress, learner_indexes)
     }
 
     /// Prepares for a new round of vote counting via recordVote.


### PR DESCRIPTION
extend commit group to learners. When make sure the group commit rule "raft log should be replicated to at least 2 group", also consider learners.

This feature is used to implement replication across DC by raft learner. Different with existing commit group which check followers, learner has less impact on leader&follower group like a TiFlash replica. It won't affect votes and won't elect itself as leader. Adding commit group for learner can switch between RPO=0 and better performance replication.