### PR TITLE
Add readability to example

### DIFF
--- a/examples/single_mem_node/main.rs
+++ b/examples/single_mem_node/main.rs
@@ -29,7 +29,8 @@ fn main() {
     // Create a storage for Raft, and here we just use a simple memory storage.
     // You need to build your own persistent storage in your production.
     // Please check the Storage trait in src/storage.rs to see how to implement one.
-    let storage = MemStorage::new_with_conf_state(ConfState::from((vec![1], vec![])));
+    let node_id = 1;
+    let storage = MemStorage::new_with_conf_state(ConfState::from((vec![node_id], vec![])));
 
     let decorator = slog_term::TermDecorator::new().build();
     let drain = slog_term::FullFormat::new(decorator).build().fuse();
@@ -43,7 +44,7 @@ fn main() {
     // Create the configuration for the Raft node.
     let cfg = Config {
         // The unique ID for the Raft node.
-        id: 1,
+        id: node_id,
         // Election tick is for how long the follower may campaign again after
         // it doesn't receive any message from the leader.
         election_tick: 10,
@@ -60,6 +61,8 @@ fn main() {
         applied: 0,
         ..Default::default()
     };
+    // After, make sure it's valid!
+    cfg.validate().unwrap();
 
     // Create the Raft node.
     let mut r = RawNode::new(&cfg, storage, &logger).unwrap();


### PR DESCRIPTION
1. We get rid of the magic number `1` and thus show that the node number must be the same in `MemStorage::new_with_conf_state` and `let cfg = Config { id: ...`
2. Adding an call `cfg.validate().unwrap()` as it is done in the documentation https://docs.rs/raft/latest/raft/