### PR TITLE
Suggest using slab for storing callbacks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,9 @@ after the write is finished.
 One simple way is to use a unique ID for the client request, and save the associated callback
 function in a hash map. When the log entry is applied, we can get the ID from the decoded entry,
 call the corresponding callback, and notify the client.
+Another way would be to use the [`slab`](https://docs.rs/slab) crate as it would return the
+index at which the callback was inserted which can then be used as the ID for that client request.
+This saves the caller from having to ensure ID uniqueness manually.
 
 You can call the `step` function when you receive the Raft messages from other nodes.
 


### PR DESCRIPTION
Added a paragraph in the docs suggesting the usage of a slab for storing the callbacks for client requests. Since it returns the index at which the callback was inserted, it takes away the burden of managing ID uniqueness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded crate documentation describing an alternative approach to managing callback request identifiers (using container insertion indices) for client notifications after Raft log application. This is explanatory only; no runtime behavior or public API changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->