### PR TITLE
fix: bump rand to 0.9.3 for default builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ fail = { version = "0.4", optional = true }
 getset = "0.1.1"
 thiserror = "1.0"
 raft-proto = { path = "proto", version = "0.7.0", default-features = false }
-rand = "0.8"
+rand = "0.9.3"
 slog = "2.2"
 slog-envlogger = { version = "2.1.0", optional = true }
 slog-stdlog = { version = "4", optional = true }

--- a/harness/Cargo.toml
+++ b/harness/Cargo.toml
@@ -23,7 +23,7 @@ prost-codec = ["raft/prost-codec"]
 raft = { path = "..", default-features = false }
 raft-proto = { path = "../proto", default-features = false }
 fail = { version = "0.4", optional = true }
-rand = "0.8"
+rand = "0.9.3"
 slog = "2.2"
 
 [dev-dependencies]

--- a/src/raft.rs
+++ b/src/raft.rs
@@ -2854,7 +2854,7 @@ impl<T: Storage> Raft<T> {
     pub fn reset_randomized_election_timeout(&mut self) {
         let prev_timeout = self.randomized_election_timeout;
         let timeout =
-            rand::thread_rng().gen_range(self.min_election_timeout..self.max_election_timeout);
+            rand::rng().random_range(self.min_election_timeout..self.max_election_timeout);
         debug!(
             self.logger,
             "reset election timeout {prev_timeout} -> {timeout} at {election_elapsed}",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded the project's random-number generation dependency to v0.9.3.
  * Internal selection method for randomized timeouts was adjusted to use the updated RNG, preserving existing ranges and behavior.
  * No user-visible functionality, behavior, or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes https://github.com/tikv/raft-rs/issues/585