### PR TITLE
try to shrink unstable entries buffer to avoid memory leak

### DIFF
--- a/src/log_unstable.rs
+++ b/src/log_unstable.rs
@@ -22,7 +22,8 @@ use slog::Logger;
 
 const SHRINK_KEEP_CAPACITY: usize = 64;
 const SHRINK_EMPTY_CAPACITY_THRESHOLD: usize = 256;
-const SHRINK_RATIO: usize = 4;
+const SHRINK_RATIO: usize = 2;
+const SHRINK_RESERVED_SIZE_RATIO: usize = 2;
 
 /// Unstable contains "unstable" log entries and snapshot state that has
 /// not yet been written to Storage.
@@ -97,6 +98,19 @@ impl Unstable {
         }
     }
 
+    /// Release the backing buffer of `entries` to further reduce memory usage.
+    ///
+    /// This is only suitable when the raft group is idle and unlikely to
+    /// propose new entries soon. Frequent release and reallocation of the
+    /// buffer can hurt performance.
+    pub fn release_entry_buffer(&mut self) {
+        if self.entries.is_empty() && self.entries.capacity() > 0 {
+            self.entries = vec![];
+        }
+    }
+
+    /// Try to shrink the capacity of `entries` when the entry count drops
+    /// to reduce memory usage.
     fn maybe_shrink_entries(&mut self) {
         let len = self.entries.len();
         let cap = self.entries.capacity();
@@ -104,7 +118,7 @@ impl Unstable {
             return;
         }
 
-        let target = len.max(SHRINK_KEEP_CAPACITY);
+        let target = (len * SHRINK_RESERVED_SIZE_RATIO).max(SHRINK_KEEP_CAPACITY);
         if cap >= target * SHRINK_RATIO {
             self.entries.shrink_to(target);
         }
@@ -239,6 +253,7 @@ mod test {
     use crate::eraftpb::{Entry, Snapshot, SnapshotMetadata};
     use crate::log_unstable::{
         Unstable, SHRINK_EMPTY_CAPACITY_THRESHOLD, SHRINK_KEEP_CAPACITY, SHRINK_RATIO,
+        SHRINK_RESERVED_SIZE_RATIO,
     };
     use crate::util::entry_approximate_size;
 
@@ -528,10 +543,14 @@ mod test {
             .map(|i| new_entry(i as u64 + 5, 1))
             .collect::<Vec<_>>();
         u.entries_size = u.entries.iter().map(entry_approximate_size).sum::<usize>();
-        let half = u.entries.len() / SHRINK_RATIO;
-        u.entries.truncate(half);
+        let shrunk_len = u.entries.len() / (SHRINK_RATIO * SHRINK_RESERVED_SIZE_RATIO);
+        u.entries.truncate(shrunk_len);
         u.entries_size = u.entries.iter().map(entry_approximate_size).sum::<usize>();
         u.maybe_shrink_entries();
-        assert!(u.entries.capacity() <= half.max(SHRINK_KEEP_CAPACITY) * SHRINK_RATIO);
+        assert!(
+            u.entries.capacity()
+                <= (shrunk_len * SHRINK_RESERVED_SIZE_RATIO).max(SHRINK_KEEP_CAPACITY)
+                    * SHRINK_RATIO
+        );
     }
 }

--- a/src/log_unstable.rs
+++ b/src/log_unstable.rs
@@ -20,6 +20,10 @@ use crate::eraftpb::{Entry, Snapshot};
 use crate::util::entry_approximate_size;
 use slog::Logger;
 
+const SHRINK_KEEP_CAPACITY: usize = 64;
+const SHRINK_EMPTY_CAPACITY_THRESHOLD: usize = 256;
+const SHRINK_RATIO: usize = 4;
+
 /// Unstable contains "unstable" log entries and snapshot state that has
 /// not yet been written to Storage.
 ///
@@ -93,6 +97,19 @@ impl Unstable {
         }
     }
 
+    fn maybe_shrink_entries(&mut self) {
+        let len = self.entries.len();
+        let cap = self.entries.capacity();
+        if cap <= SHRINK_EMPTY_CAPACITY_THRESHOLD {
+            return;
+        }
+
+        let target = len.max(SHRINK_KEEP_CAPACITY);
+        if cap >= target * SHRINK_RATIO {
+            self.entries.shrink_to(target);
+        }
+    }
+
     /// Clears the unstable entries and moves the stable offset up to the
     /// last index, if there is any.
     pub fn stable_entries(&mut self, index: u64, term: u64) {
@@ -112,6 +129,7 @@ impl Unstable {
             self.offset = entry.get_index() + 1;
             self.entries.clear();
             self.entries_size = 0;
+            self.maybe_shrink_entries();
         } else {
             fatal!(
                 self.logger,
@@ -147,6 +165,7 @@ impl Unstable {
     pub fn restore(&mut self, snap: Snapshot) {
         self.entries.clear();
         self.entries_size = 0;
+        self.maybe_shrink_entries();
         self.offset = snap.get_metadata().index + 1;
         self.snapshot = Some(snap);
     }
@@ -166,6 +185,7 @@ impl Unstable {
             self.offset = after;
             self.entries.clear();
             self.entries_size = 0;
+            self.maybe_shrink_entries();
         } else {
             // truncate to after and copy to self.entries then append
             let off = self.offset;
@@ -174,6 +194,7 @@ impl Unstable {
                 self.entries_size -= entry_approximate_size(e);
             }
             self.entries.truncate((after - off) as usize);
+            self.maybe_shrink_entries();
         }
         self.entries.extend_from_slice(ents);
         self.entries_size += ents.iter().map(entry_approximate_size).sum::<usize>();
@@ -216,7 +237,9 @@ impl Unstable {
 #[cfg(test)]
 mod test {
     use crate::eraftpb::{Entry, Snapshot, SnapshotMetadata};
-    use crate::log_unstable::Unstable;
+    use crate::log_unstable::{
+        Unstable, SHRINK_EMPTY_CAPACITY_THRESHOLD, SHRINK_KEEP_CAPACITY, SHRINK_RATIO,
+    };
     use crate::util::entry_approximate_size;
 
     fn new_entry(index: u64, term: u64) -> Entry {
@@ -478,5 +501,37 @@ mod test {
             let entries_size = wentries.iter().map(entry_approximate_size).sum::<usize>();
             assert_eq!(u.entries_size, entries_size);
         }
+    }
+
+    #[test]
+    fn test_maybe_shrink_entries() {
+        let mut entries = Vec::with_capacity(SHRINK_EMPTY_CAPACITY_THRESHOLD + 1);
+        entries.resize_with(SHRINK_EMPTY_CAPACITY_THRESHOLD + 1, || new_entry(5, 1));
+        let entries_size = entries.iter().map(entry_approximate_size).sum::<usize>();
+        let mut u = Unstable {
+            entries,
+            entries_size,
+            offset: 5,
+            snapshot: None,
+            logger: crate::default_logger(),
+        };
+
+        let grown_capacity = u.entries.capacity();
+        assert!(grown_capacity > SHRINK_EMPTY_CAPACITY_THRESHOLD);
+
+        let last = u.entries.last().cloned().unwrap();
+        u.stable_entries(last.index, last.term);
+        assert!(u.entries.is_empty());
+        assert_eq!(u.entries.capacity(), SHRINK_KEEP_CAPACITY);
+
+        u.entries = (0..grown_capacity)
+            .map(|i| new_entry(i as u64 + 5, 1))
+            .collect::<Vec<_>>();
+        u.entries_size = u.entries.iter().map(entry_approximate_size).sum::<usize>();
+        let half = u.entries.len() / SHRINK_RATIO;
+        u.entries.truncate(half);
+        u.entries_size = u.entries.iter().map(entry_approximate_size).sum::<usize>();
+        u.maybe_shrink_entries();
+        assert!(u.entries.capacity() <= half.max(SHRINK_KEEP_CAPACITY) * SHRINK_RATIO);
     }
 }


### PR DESCRIPTION
The issue is https://github.com/tikv/tikv/issues/19593 . The unstable entries can consume too much memory (in this case > 20GB) when there are about ~250k raft groups. So this PR try to shrink the entry buffer to avoid memory leak.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced memory usage by opportunistically shrinking retained capacity for log entry buffers after clears, truncations, or restores to avoid holding large unused allocations.

* **New Features**
  * Added a public API to aggressively release internal entry buffers when they are empty.

* **Tests**
  * Added test coverage validating the memory-reduction behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tikv/raft-rs/pull/589)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->