### PR TITLE
docs(proto): document ConfChange.context and fix an Entry doc typo

### DIFF
--- a/proto/proto/eraftpb.proto
+++ b/proto/proto/eraftpb.proto
@@ -19,7 +19,7 @@ enum EntryType {
 //
 // For configuration changes, the data will contain the ConfChange message and the
 // context will provide anything needed to assist the configuration change. The context
-// if for the user to set and use in this case.
+// is for the user to set and use in this case.
 message Entry {
     EntryType entry_type = 1;
     uint64 term = 2;
@@ -142,9 +142,17 @@ enum ConfChangeType {
     AddLearnerNode = 2;
 }
 
+// ConfChange initiates a simple "one at a time" membership change, carried in an
+// EntryConfChange log entry.
+//
+// As with ConfChangeV2, the context is treated as an opaque payload: it is set by the
+// user and can be used to attach an action on the state machine to the application of
+// the config change. The configuration change becomes active when the entry is
+// *applied* to the state machine, not when it is appended to the log.
 message ConfChange {
     ConfChangeType change_type = 2;
     uint64 node_id = 3;
+    // Opaque, user-defined payload associated with this configuration change.
     bytes context = 4;
 
     uint64 id = 1;


### PR DESCRIPTION
Minor docs-only change to \`eraftpb.proto\`:

- Document \`ConfChange.context\`. The equivalent field on \`ConfChangeV2\` is already documented; this one had no comment.
- Fix a typo in the \`Entry\` doc comment ("The context if for the user" -> "is for the user").

No behavior change. Independent of #99 (that issue is about the removed bootstrap peer-context behavior, see my comment there).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated protocol documentation to clarify how configuration changes become active and what the configuration-change context payload represents.
  * Adjusted explanatory comments, including clarifying the context field as an opaque, user-defined value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->