### PR TITLE
deprecate the unused `Peer` struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,7 +532,9 @@ pub use raft_proto::eraftpb;
 pub use raft_proto::protocompat;
 #[allow(deprecated)]
 pub use raw_node::is_empty_snap;
-pub use raw_node::{LightReady, Peer, RawNode, Ready, SnapshotStatus};
+pub use raw_node::{LightReady, RawNode, Ready, SnapshotStatus};
+#[allow(deprecated)]
+pub use raw_node::Peer;
 pub use read_only::{ReadOnlyOption, ReadState};
 pub use status::Status;
 pub use storage::{GetEntriesContext, RaftState, Storage};
@@ -559,7 +561,9 @@ pub mod prelude {
 
     pub use crate::storage::{RaftState, Storage};
 
-    pub use crate::raw_node::{Peer, RawNode, Ready, SnapshotStatus};
+    pub use crate::raw_node::{RawNode, Ready, SnapshotStatus};
+    #[allow(deprecated)]
+    pub use crate::raw_node::Peer;
 
     pub use crate::Progress;
 

--- a/src/raw_node.rs
+++ b/src/raw_node.rs
@@ -39,13 +39,21 @@ type Bytes = bytes::Bytes;
 #[cfg(not(feature = "protobuf-codec"))]
 type Bytes = Vec<u8>;
 
-/// Represents a Peer node in the cluster.
+/// Represents a peer node in the cluster.
+///
+/// This type is no longer used by the crate. Earlier versions accepted an initial peer
+/// set when constructing a node and bootstrapped the cluster by turning those peers into
+/// `ConfChange` entries, using each peer's `context` as the change's context. That path
+/// has been removed: a cluster is now bootstrapped by the application proposing
+/// `ConfChange` entries itself (see `RawNode::propose_conf_change`).
 #[derive(Debug, Default)]
+#[deprecated(
+    note = "Peer is unused; bootstrap a cluster by proposing ConfChange entries via RawNode::propose_conf_change"
+)]
 pub struct Peer {
     /// The ID of the peer.
     pub id: u64,
-    /// If there is context associated with the peer (like connection information), it can be
-    /// serialized and stored here.
+    /// Opaque context that earlier versions attached to this peer's bootstrap `ConfChange`.
     pub context: Option<Vec<u8>>,
 }
 


### PR DESCRIPTION
Addresses #99.

\`Peer\` is public and re-exported, but it is never constructed or used anywhere in the crate. It is a leftover from the old bootstrap API that accepted an initial peer set and turned it into \`ConfChange\` entries using each peer's context. That path was removed; a cluster is now bootstrapped by the application proposing \`ConfChange\` entries directly (\`RawNode::propose_conf_change\`), so \`Peer\` only lingers as a confusing, unused type. Its doc still implied the old context-injection behavior, which is the confusion #99 is about.

This marks \`Peer\` \`#[deprecated]\` (rather than removing it, to avoid a breaking change) and updates its docs to describe the current state. The two re-exports get \`#[allow(deprecated)]\`, matching the existing \`is_empty_snap\` pattern, so the crate still builds under \`--deny=warnings\`.

As mentioned in #99, happy to go a different way if you would rather keep \`Peer\` and just document that it is unused. \`cargo check\` is clean with \`RUSTFLAGS=--deny=warnings\`.

Signed-off-by: satyakwok <119509589+satyakwok@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * `Peer` type is now deprecated. Use `RawNode::propose_conf_change` for cluster bootstrapping instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->