### PR TITLE
Fix minor typo

### DIFF
--- a/proto/proto/eraftpb.proto
+++ b/proto/proto/eraftpb.proto
@@ -19,7 +19,7 @@ enum EntryType {
 //
 // For configuration changes, the data will contain the ConfChange message and the
 // context will provide anything needed to assist the configuration change. The context
-// if for the user to set and use in this case.
+// is for the user to set and use in this case.
 message Entry {
     EntryType entry_type = 1;
     uint64 term = 2;


### PR DESCRIPTION
Came across a very minor typo on the `eraftproto.pb` file which is easy to review and merge. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a wording error in the `Entry` documentation comment for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->